### PR TITLE
Add option to clear eBPF maps

### DIFF
--- a/non-GPL/HostIsolationMapsUtil/UpdateMaps.c
+++ b/non-GPL/HostIsolationMapsUtil/UpdateMaps.c
@@ -26,6 +26,9 @@ ebpf_update_map(const char *map_path,
                 uint32_t key,
                 uint32_t val);
 
+static int
+ebpf_clear_map(const char *map_path);
+
 int
 ebpf_map_allowed_IPs_add(uint32_t IPaddr)
 {
@@ -42,6 +45,18 @@ ebpf_map_allowed_pids_add(uint32_t pid)
     uint32_t val = 1;   // values are not used in the hash map
 
     return ebpf_update_map(EBPF_ALLOWED_PIDS_MAP_PATH, key, val);
+}
+
+int
+ebpf_map_allowed_IPs_clear()
+{
+    return ebpf_clear_map(EBPF_ALLOWED_IPS_MAP_PATH);
+}
+
+int
+ebpf_map_allowed_pids_clear()
+{
+    return ebpf_clear_map(EBPF_ALLOWED_PIDS_MAP_PATH);
 }
 
 static int
@@ -71,6 +86,56 @@ ebpf_update_map(const char *map_path, uint32_t key, uint32_t val)
         ebpf_log("Error: failed to add entry to map: %s, errno=%d\n", map_path, errno);
         goto cleanup;
     }
+
+cleanup:
+    if (map_fd >= 0)
+    {
+        close(map_fd);
+    }
+
+    return rv;
+}
+
+static int
+ebpf_clear_map(const char *map_path)
+{
+    int rv = 0;
+    int map_fd = -1;
+    uint32_t key = -1;
+    uint32_t next_key = -1;
+
+    if (map_path == NULL)
+    {
+        ebpf_log("Error: map_path is NULL\n");
+        rv = -1;
+        goto cleanup;
+    }
+
+    map_fd = bpf_obj_get(map_path);
+    if (map_fd < 0)
+    {
+        ebpf_log("Error: run with sudo or make sure %s exists\n", map_path);
+        rv = -1;
+        goto cleanup;
+    }
+
+    // get the first key
+    if (bpf_map_get_next_key(map_fd, NULL, &key) < 0)
+    {
+        // map is already empty
+        goto cleanup;
+    }
+
+    // iterate over map
+    while (0 == bpf_map_get_next_key(map_fd, &key, &next_key))
+    {
+        // return value 0 means 'key' exists and 'next_key' has been set
+        (void)bpf_map_delete_elem(map_fd, &key);
+        key = next_key;
+    }
+
+    // -1 was returned so 'key' is the last element - delete it
+    (void)bpf_map_delete_elem(map_fd, &key);
 
 cleanup:
     if (map_fd >= 0)

--- a/non-GPL/HostIsolationMapsUtil/UpdateMaps.h
+++ b/non-GPL/HostIsolationMapsUtil/UpdateMaps.h
@@ -28,3 +28,19 @@ ebpf_map_allowed_IPs_add(uint32_t IPaddr);
  */
 int
 ebpf_map_allowed_pids_add(uint32_t pid);
+
+/**
+ * @brief Clear IP allowlist
+ *
+ * @return Error value (0 for success)
+ */
+int
+ebpf_map_allowed_IPs_clear();
+
+/**
+ * @brief Clear pid allowlist
+ *
+ * @return Error value (0 for success)
+ */
+int
+ebpf_map_allowed_pids_clear();


### PR DESCRIPTION
Add
`ebpf_map_allowed_IPs_clear()`
`ebpf_map_allowed_pids_clear()`

There is no bpf syscall to clear the entire map at once so it is necessary to iterate over it and delete keys one by one (it is safe to do so, but it's not thread-safe or even process-safe).