### PR TITLE
Exclude contrib folder from stats

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+contrib/* linguist-vendored


### PR DESCRIPTION
This is useful to avoid cluttering the stats with the many additions that are done by directly committing generated files and downloaded dependencies into contrib.


Reference on linguist docs
- https://github.com/github/linguist/blob/0c7f82f88a2fb482db3a02812cbb4b8aab7308d1/docs/overrides.md#using-gitattributes