### PR TITLE
Fix libbpf map file descriptor leak

### DIFF
--- a/contrib/libbpf/src/libbpf.c
+++ b/contrib/libbpf/src/libbpf.c
@@ -4137,6 +4137,10 @@ bpf_object__reuse_map(struct bpf_map *map)
 		close(pin_fd);
 		return err;
 	}
+
+	// close the old descriptor, otherwise we leave a dangling ref to map
+	close(pin_fd);
+
 	map->pinned = true;
 	pr_debug("reused pinned map at '%s'\n", map->pin_path);
 


### PR DESCRIPTION
Pinned maps stayed loaded in the kernel (visible in bpftool map list)
even after closing and unloading programs which used them, as well as
removing their file entries from BPF FS.

The cause was the reuse_map function in libbpf not closing the old
map file descriptor leaving a dangling reference and preventing
the kernel from unloading the map.