### PR TITLE
TcFilter Improved compiler directives to correctly compile the Kernel target

### DIFF
--- a/GPL/HostIsolation/TcFilter/Kerneldefs.h
+++ b/GPL/HostIsolation/TcFilter/Kerneldefs.h
@@ -351,10 +351,9 @@ struct ethhdr {
 } __attribute__((packed));
 
 // This header might be included in userspace programs (e.g TcFilterTest.cpp)
-// that want to share some definitions with kernel space programs (TcFilter.bpf.c).
-// In this case, is very likely that the userspace program will be compiled with libbpf
-// which already defines the types below
-#ifndef __LIBBPF_BPF_H
+// where we want to share some definitions with kernel space programs (TcFilter.bpf.c).
+// In this case, we need to gate some specific kernel definitions that are not needed in userspace.
+#ifdef __KERNEL__
 enum bpf_map_type {
 	BPF_MAP_TYPE_UNSPEC,
 	BPF_MAP_TYPE_HASH,
@@ -406,5 +405,7 @@ struct __sk_buff {
 	
 	// Note: there are more fields but we don't use them
 };
+#else
+#define __aligned_u64 __u64 __attribute__((aligned(8)))
+#endif // __KERNEL__
 
-#endif

--- a/GPL/HostIsolation/TcFilter/Makefile
+++ b/GPL/HostIsolation/TcFilter/Makefile
@@ -35,8 +35,23 @@ CXXFLAGS ?= -g -Wall -Wextra -pthread
 TEST_LIBS := 
 TEST_FILES ?= $(wildcard *Test.cpp)
 
+# We never want the stdinc flags in our BPF program, they can contain
+# things the eBPF program cannot compile or provide LLVM builtins that we can't use.
+NOSTDINC_FLAGS += -nostdinc -isystem $(shell $(CC) -print-file-name=include)
+
 TcFilter.bpf.o: TcFilter.bpf.c $(wildcard %.h) Kerneldefs.h
-	$(CLANG) -g -O2 -I../../../contrib/kernel_hdrs -emit-llvm -c $< -o - | $(LLC) -march=bpf -mcpu=v2 -filetype=obj -o $@
+	$(CLANG) -g -O2 $(NOSTDINC_FLAGS) \
+		-I../../../contrib/kernel_hdrs \
+		-D__KERNEL__ \
+		-D__BPF_TRACING__ \
+		-Wno-unused-value \
+		-Wno-pointer-sign \
+		-Wno-compare-distinct-pointer-types \
+		-Wno-gnu-variable-sized-type-not-at-end \
+		-Wno-address-of-packed-member \
+		-Wno-tautological-compare \
+		-fno-asynchronous-unwind-tables \
+		-emit-llvm -c $< -o - | $(LLC) -march=bpf -mcpu=v2 -filetype=obj -o $@
 
 .PHONY: clean
 clean:

--- a/GPL/HostIsolation/TcFilter/TcFilterTest.cpp
+++ b/GPL/HostIsolation/TcFilter/TcFilterTest.cpp
@@ -18,6 +18,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
+#include "Kerneldefs.h"
 #include <bpf/bpf.h>
 #include <bpf/bpf_endian.h>
 #include <bpf/libbpf.h>
@@ -27,7 +28,6 @@
 #include <sched.h>
 #include <sys/resource.h>
 
-#include "Kerneldefs.h"
 #include "TcFilterdefs.h"
 
 #define OBJECT_PATH_ENV_VAR "ELASTIC_EBPF_TC_FILTER_OBJ_PATH"


### PR DESCRIPTION
- Included the __KERNEL__ and __BPF_TRACING__ definitions
used by libbpf and Kerneldefs.h
- Added compilation directives to do better llvm passes while undiwning
  tables and to produce only meaningful errors


This is a follow up to my previous PR #21 that had some issues compiling in certain environments, like

```
 error: ‘__aligned_u64’ does not name a type
   __aligned_u64 key;
   ^~~~~~~~~~~~~
```
