### PR TITLE
Add option to allow IP subnets

### DIFF
--- a/GPL/HostIsolation/TcFilter/TcFilter.bpf.c
+++ b/GPL/HostIsolation/TcFilter/TcFilter.bpf.c
@@ -70,24 +70,24 @@ allow_destination_IP(
         .data = ip->daddr,
     };
 
-    /* Check allowed subnets first */
-    elem = bpf_map_lookup_elem(&allowed_subnets, &lpm_key);
+    /* Check allowed IPs map first */
+    elem = bpf_map_lookup_elem(&allowed_IPs, &ip->daddr);
     if (elem)
     {
-        /* IP matches allowed subnet */
+        /* IP is allowed */
         return 1;
     }
 
-    /* Now check allowed IPs map */
-    elem = bpf_map_lookup_elem(&allowed_IPs, &ip->daddr);
+    /* Now check allowed subnets */
+    elem = bpf_map_lookup_elem(&allowed_subnets, &lpm_key);
     if (!elem)
     {
-        /* destination IP not in allowlist - reject */
+        /* destination IP not within any allowed subnets - reject */
         return 0;
     }
     else
     {
-        /* IP is allowed */
+        /* IP matches allowed subnet */
         return 1;
     }
 }

--- a/GPL/HostIsolation/TcFilter/TcFilter.bpf.c
+++ b/GPL/HostIsolation/TcFilter/TcFilter.bpf.c
@@ -32,6 +32,14 @@
 // you took NULL for granted didn't you :)
 #define NULL 0
 
+#define BPF_F_NO_PREALLOC	(1U << 0)
+
+/* Key of an a BPF_MAP_TYPE_LPM_TRIE entry */
+struct bpf_lpm_trie_key {
+	__u32	prefixlen;	/* up to 32 for AF_INET, 128 for AF_INET6 */
+	__u32	data;	/* Arbitrary size */
+};
+
 struct
 {
     __uint(type, BPF_MAP_TYPE_HASH);
@@ -41,13 +49,36 @@ struct
     __uint(pinning, LIBBPF_PIN_BY_NAME);
 } allowed_IPs __section(".maps");
 
+struct
+{
+    __uint(type, BPF_MAP_TYPE_LPM_TRIE);
+    __uint(key_size, 8);
+    __uint(value_size, sizeof(int));
+    __uint(max_entries, 256);
+    __uint(pinning, LIBBPF_PIN_BY_NAME);
+    __uint(map_flags, BPF_F_NO_PREALLOC);
+} allowed_subnets __section(".maps");
+
 __attribute__((always_inline))
 static int
 allow_destination_IP(
     struct iphdr *ip)
 {
     __u32 *elem = NULL;
+    struct bpf_lpm_trie_key lpm_key = {
+        .prefixlen = 32,
+        .data = ip->daddr,
+    };
 
+    /* Check allowed subnets first */
+    elem = bpf_map_lookup_elem(&allowed_subnets, &lpm_key);
+    if (elem)
+    {
+        /* IP matches allowed subnet */
+        return 1;
+    }
+
+    /* Now check allowed IPs map */
     elem = bpf_map_lookup_elem(&allowed_IPs, &ip->daddr);
     if (!elem)
     {

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ eBPF programs consist of:
 
 Tools and loaders consist of:
 
-    UpdateIPsDemo - Userspace tool for updating IP allowlist
+    UpdateIPsDemo - Userspace tool for updating IP and subnet allowlist
 
     UpdatePidsDemo - Userspace tool for updating PID allowlist
 

--- a/non-GPL/Common/Common.c
+++ b/non-GPL/Common/Common.c
@@ -16,6 +16,34 @@
 
 #include "Common.h"
 
+struct ebpf_maps_info ebpf_maps[EBPF_MAP_NUM] =
+{
+{
+    .type    = BPF_MAP_TYPE_HASH,
+    .name        = EBPF_ALLOWED_IPS_MAP_NAME,
+    .key_size    = sizeof(int),
+    .value_size  = sizeof(int),
+    .max_entries = 512,
+    .map_flags       = 0
+},
+{
+    .type    = BPF_MAP_TYPE_LPM_TRIE,
+    .name        = EBPF_ALLOWED_SUBNETS_MAP_NAME,
+    .key_size    = 8,
+    .value_size  = sizeof(int),
+    .max_entries = 256,
+    .map_flags       = BPF_F_NO_PREALLOC
+},
+{
+    .type    = BPF_MAP_TYPE_HASH,
+    .name        = EBPF_ALLOWED_PIDS_MAP_NAME,
+    .key_size    = sizeof(int),
+    .value_size  = sizeof(int),
+    .max_entries = 128,
+    .map_flags       = 0
+},
+};
+
 // common log function
 static libbpf_print_fn_t g_log_func = libbpf_print_fn;
 

--- a/non-GPL/Common/Common.h
+++ b/non-GPL/Common/Common.h
@@ -50,6 +50,8 @@ ebpf_set_log_func(libbpf_print_fn_t fn);
 #define EBPF_MAP_DIRECTORY "/sys/fs/bpf/elastic/endpoint"
 #define EBPF_ALLOWED_IPS_MAP_NAME "allowed_IPs"
 #define EBPF_ALLOWED_IPS_MAP_PATH "/sys/fs/bpf/elastic/endpoint/allowed_IPs"
+#define EBPF_ALLOWED_SUBNETS_MAP_NAME "allowed_subnets"
+#define EBPF_ALLOWED_SUBNETS_MAP_PATH "/sys/fs/bpf/elastic/endpoint/allowed_subnets"
 #define EBPF_ALLOWED_PIDS_MAP_NAME "allowed_pids"
 #define EBPF_ALLOWED_PIDS_MAP_PATH "/sys/fs/bpf/elastic/endpoint/allowed_pids"
 

--- a/non-GPL/Common/Common.h
+++ b/non-GPL/Common/Common.h
@@ -6,9 +6,41 @@
  * you may not use this file except in compliance with the Elastic License 2.0.
  */
 
+#ifndef EBPF_COMMON_H
+#define EBPF_COMMON_H
 
 #include <bpf/bpf.h>
 #include <bpf/libbpf.h>
+
+#define EBPF_MAP_PARENT_DIRECTORY       "/sys/fs/bpf/elastic"
+#define EBPF_MAP_DIRECTORY              "/sys/fs/bpf/elastic/endpoint"
+#define EBPF_ALLOWED_IPS_MAP_NAME       "allowed_IPs"
+#define EBPF_ALLOWED_IPS_MAP_PATH       "/sys/fs/bpf/elastic/endpoint/allowed_IPs"
+#define EBPF_ALLOWED_SUBNETS_MAP_NAME   "allowed_subnets"
+#define EBPF_ALLOWED_SUBNETS_MAP_PATH   "/sys/fs/bpf/elastic/endpoint/allowed_subnets"
+#define EBPF_ALLOWED_PIDS_MAP_NAME      "allowed_pids"
+#define EBPF_ALLOWED_PIDS_MAP_PATH      "/sys/fs/bpf/elastic/endpoint/allowed_pids"
+
+struct ebpf_maps_info
+{
+    enum bpf_map_type type;
+    const char        *name;
+    int               key_size;
+    int               value_size;
+    int               max_entries;
+    uint32_t          map_flags;
+};
+
+enum ebpf_hostisolation_map
+{
+    EBPF_MAP_ALLOWED_IPS = 0,
+    EBPF_MAP_ALLOWED_SUBNETS,
+    EBPF_MAP_ALLOWED_PIDS,
+    EBPF_MAP_NUM
+};
+
+// ebpf map metadata
+extern struct ebpf_maps_info ebpf_maps[EBPF_MAP_NUM];
 
 /**
  * @brief Default libbpf log function
@@ -45,13 +77,4 @@ ebpf_default_log_func();
  */
 void
 ebpf_set_log_func(libbpf_print_fn_t fn);
-
-#define EBPF_MAP_PARENT_DIRECTORY "/sys/fs/bpf/elastic"
-#define EBPF_MAP_DIRECTORY "/sys/fs/bpf/elastic/endpoint"
-#define EBPF_ALLOWED_IPS_MAP_NAME "allowed_IPs"
-#define EBPF_ALLOWED_IPS_MAP_PATH "/sys/fs/bpf/elastic/endpoint/allowed_IPs"
-#define EBPF_ALLOWED_SUBNETS_MAP_NAME "allowed_subnets"
-#define EBPF_ALLOWED_SUBNETS_MAP_PATH "/sys/fs/bpf/elastic/endpoint/allowed_subnets"
-#define EBPF_ALLOWED_PIDS_MAP_NAME "allowed_pids"
-#define EBPF_ALLOWED_PIDS_MAP_PATH "/sys/fs/bpf/elastic/endpoint/allowed_pids"
-
+#endif

--- a/non-GPL/HostIsolation/KprobeConnectHook/KprobeLoader.h
+++ b/non-GPL/HostIsolation/KprobeConnectHook/KprobeLoader.h
@@ -6,6 +6,8 @@
  * you may not use this file except in compliance with the Elastic License 2.0.
  */
 
+#ifndef EBPF_KPROBELOADER_H
+#define EBPF_KPROBELOADER_H
 
 #include <Common.h>
 
@@ -65,4 +67,4 @@ ebpf_link_destroy(struct bpf_link *link);
  */
 void
 ebpf_object_close(struct bpf_object *obj);
-
+#endif

--- a/non-GPL/HostIsolationMapsUtil/UpdateMaps.c
+++ b/non-GPL/HostIsolationMapsUtil/UpdateMaps.c
@@ -71,6 +71,12 @@ ebpf_map_allowed_IPs_clear()
 }
 
 int
+ebpf_map_allowed_subnets_clear()
+{
+    return ebpf_clear_map(EBPF_ALLOWED_SUBNETS_MAP_PATH);
+}
+
+int
 ebpf_map_allowed_pids_clear()
 {
     return ebpf_clear_map(EBPF_ALLOWED_PIDS_MAP_PATH);

--- a/non-GPL/HostIsolationMapsUtil/UpdateMaps.c
+++ b/non-GPL/HostIsolationMapsUtil/UpdateMaps.c
@@ -27,8 +27,7 @@ ebpf_update_map(const char *map_path,
                 const void *key,
                 const void *val);
 static int
-ebpf_create_map(const char *map_path,
-                enum ebpf_hostisolation_map map_id,
+ebpf_create_map(enum ebpf_hostisolation_map map_id,
                 int *map_fd);
 static int
 ebpf_clear_map(const char *map_path,
@@ -88,8 +87,7 @@ ebpf_map_allowed_pids_clear()
 }
 
 static int
-ebpf_create_map(const char *map_path,
-                enum ebpf_hostisolation_map map_id,
+ebpf_create_map(enum ebpf_hostisolation_map map_id,
                 int *map_fd)
 {
     int rv = 0;
@@ -139,7 +137,7 @@ ebpf_update_map(const char *map_path, enum ebpf_hostisolation_map map_id, const 
     if (map_fd < 0)
     {
         // perhaps the map does not exist, try to create it and pin to bpf fs
-        rv = ebpf_create_map(map_path, map_id, &map_fd);
+        rv = ebpf_create_map(map_id, &map_fd);
         if (rv)
         {
             ebpf_log("Error updating map, make sure to run with sudo. Errno=%d\n", errno);
@@ -189,7 +187,7 @@ ebpf_clear_map(const char *map_path,
     if (map_fd < 0)
     {
         // perhaps the map does not exist, try to create it
-        rv = ebpf_create_map(map_path, map_id, &map_fd);
+        rv = ebpf_create_map(map_id, &map_fd);
         if (rv)
         {
             ebpf_log("Error clearing map, make sure to run with sudo. Errno=%d\n", errno);

--- a/non-GPL/HostIsolationMapsUtil/UpdateMaps.h
+++ b/non-GPL/HostIsolationMapsUtil/UpdateMaps.h
@@ -8,7 +8,7 @@
 
 
 //
-// Host Isolation - tool for updating map of allowed IPs and pids
+// Host Isolation - tool for updating maps of allowed IPs, subnets and pids
 //
 
 /**
@@ -46,6 +46,14 @@ ebpf_map_allowed_pids_add(uint32_t pid);
  */
 int
 ebpf_map_allowed_IPs_clear();
+
+/**
+ * @brief Clear IP subnet allowlist
+ *
+ * @return Error value (0 for success)
+ */
+int
+ebpf_map_allowed_subnets_clear();
 
 /**
  * @brief Clear pid allowlist

--- a/non-GPL/HostIsolationMapsUtil/UpdateMaps.h
+++ b/non-GPL/HostIsolationMapsUtil/UpdateMaps.h
@@ -21,6 +21,16 @@ int
 ebpf_map_allowed_IPs_add(uint32_t IPaddr);
 
 /**
+ * @brief Add an IP subnet to the subnet allowlist
+ *
+ * @param[in] IPaddr IP address in uint format
+ * @param[in] netmask subnet mask in uint format (0-32)
+ * @return Error value (0 for success)
+ */
+int
+ebpf_map_allowed_subnets_add(uint32_t IPaddr, uint32_t netmask);
+
+/**
  * @brief Add a single PID (process ID) to the PID allowlist
  *
  * @param[in] pid PID number

--- a/non-GPL/HostIsolationMapsUtil/UpdateMaps.h
+++ b/non-GPL/HostIsolationMapsUtil/UpdateMaps.h
@@ -6,6 +6,8 @@
  * you may not use this file except in compliance with the Elastic License 2.0.
  */
 
+#ifndef EBPF_UPDATE_MAPS_H
+#define EBPF_UPDATE_MAPS_H
 
 //
 // Host Isolation - tool for updating maps of allowed IPs, subnets and pids
@@ -62,3 +64,4 @@ ebpf_map_allowed_subnets_clear();
  */
 int
 ebpf_map_allowed_pids_clear();
+#endif

--- a/non-GPL/TcLoader/TcLoader.h
+++ b/non-GPL/TcLoader/TcLoader.h
@@ -6,6 +6,8 @@
  * you may not use this file except in compliance with the Elastic License 2.0.
  */
 
+#ifndef EBPF_TCLOADER_H
+#define EBPF_TCLOADER_H
 
 #include <linux/netlink.h>
 #include <linux/rtnetlink.h>
@@ -83,6 +85,4 @@ int
 netlink_filter_add_end(int fd,
                        struct netlink_ctx *ctx,
                        const char *ebpf_obj_filename);
-
-
-
+#endif

--- a/non-GPL/TcLoader/TcLoaderDemo.c
+++ b/non-GPL/TcLoader/TcLoaderDemo.c
@@ -45,8 +45,11 @@ main(int argc,
     struct bpf_program *p = NULL;
     struct bpf_object *obj = NULL;
     struct bpf_map *map = NULL;
+    const char *map_name = NULL;
+    char buf[256] = {0};
     int prog_fd_dupd = 0;
     int rv = -1;
+
 
     memset(&nl_ctx, 0, sizeof(nl_ctx));
 
@@ -130,7 +133,15 @@ main(int argc,
     bpf_object__for_each_map(map, obj)
     {
         bpf_map__set_ifindex(map, 0); //?
-        bpf_map__set_pin_path(map, EBPF_MAP_DIRECTORY "/" EBPF_ALLOWED_IPS_MAP_NAME);
+        map_name = bpf_map__name(map);
+        if (map_name)
+        {
+            rv = snprintf(buf, sizeof(buf), EBPF_MAP_DIRECTORY "/" "%s", map_name);
+            if (rv > 0)
+            {
+                bpf_map__set_pin_path(map, buf);
+            }
+        }
     }
 
     rv = bpf_object__load(obj);


### PR DESCRIPTION
The allowed_subnets map will contain user-defined IPs and subnets.
The allowed_IPs map will now only be used by the KprobeConnectHook program
to dynamically add destination IPs that allowed processes want to connect to.

The TcFilter network filter checks both maps and allows the packet to
be transmitted if it finds a match in either map.