### PR TITLE
Disable stack protector for TcFilter

### DIFF
--- a/GPL/HostIsolation/TcFilter/Makefile
+++ b/GPL/HostIsolation/TcFilter/Makefile
@@ -50,6 +50,7 @@ TcFilter.bpf.o: TcFilter.bpf.c $(wildcard %.h) Kerneldefs.h
 		-Wno-gnu-variable-sized-type-not-at-end \
 		-Wno-address-of-packed-member \
 		-Wno-tautological-compare \
+		-fno-stack-protector \
 		-fno-asynchronous-unwind-tables \
 		-emit-llvm -c $< -o - | $(LLC) -march=bpf -mcpu=v2 -filetype=obj -o $@
 


### PR DESCRIPTION
Some distributions enable it by default, it is incompatible
with the way how bpf programs need to be compiled because `__stack_chk_fail` is not available as builtin for the BPF target.


It leads to:

```
error: <unknown>:0:0: in function classifier i32 (%struct.__sk_buff*): A call to built-in function '__stack_chk_fail' is not supported.
```
