### PR TITLE
Fix map creation on AWS Linux

### DIFF
--- a/non-GPL/HostIsolationMapsUtil/UpdateMaps.c
+++ b/non-GPL/HostIsolationMapsUtil/UpdateMaps.c
@@ -100,12 +100,11 @@ ebpf_create_map(enum ebpf_hostisolation_map map_id,
         goto cleanup;
     }
 
-    fd = bpf_create_map_name(ebpf_maps[map_id].type,
-                             ebpf_maps[map_id].name,
-                             ebpf_maps[map_id].key_size,
-                             ebpf_maps[map_id].value_size,
-                             ebpf_maps[map_id].max_entries,
-                             ebpf_maps[map_id].map_flags);
+    fd = bpf_create_map(ebpf_maps[map_id].type,
+                        ebpf_maps[map_id].key_size,
+                        ebpf_maps[map_id].value_size,
+                        ebpf_maps[map_id].max_entries,
+                        ebpf_maps[map_id].map_flags);
 
     if (fd < 0)
     {


### PR DESCRIPTION
AWS has an old kernel (4.14) where struct bpf_map did not have
the name field. Creating a map with a name caused an error.
Instead, create a map with no name. The maps are pinned to BPF FS
so bpftool should still show the names properly with 'map list'.