### PR TITLE
tests: BPFTcFilterTests map unpin on teardown

### DIFF
--- a/GPL/HostIsolation/TcFilter/BPFTcFilterTests.cpp
+++ b/GPL/HostIsolation/TcFilter/BPFTcFilterTests.cpp
@@ -95,12 +95,20 @@ protected:
 
         m_prog_fd = bpf_program__fd(prog);
     }
+
     virtual void
     TearDown() override
     {
+        struct bpf_map *allowed_ips_map = bpf_object__find_map_by_name(m_obj, "allowed_IPs");
+        bpf_map__unpin(allowed_ips_map, bpf_map__get_pin_path(allowed_ips_map));
+
+        struct bpf_map *allowed_subnets_map = bpf_object__find_map_by_name(m_obj, "allowed_subnets");
+        bpf_map__unpin(allowed_subnets_map, bpf_map__get_pin_path(allowed_subnets_map));
+
         bpf_object__close(m_obj);
         m_prog_fd = -1;
     }
+
     static void
     SetUpTestSuite()
     {

--- a/GPL/HostIsolation/TcFilter/BPFTcFilterTests.cpp
+++ b/GPL/HostIsolation/TcFilter/BPFTcFilterTests.cpp
@@ -99,11 +99,30 @@ protected:
     virtual void
     TearDown() override
     {
+        int err = 0;
         struct bpf_map *allowed_ips_map = bpf_object__find_map_by_name(m_obj, "allowed_IPs");
-        bpf_map__unpin(allowed_ips_map, bpf_map__get_pin_path(allowed_ips_map));
+        if(!allowed_ips_map)
+        {
+            FAIL() << "Could not find the allowed_IPs map";
+            return;
+        }
+        err = bpf_map__unpin(allowed_ips_map, bpf_map__get_pin_path(allowed_ips_map));
+        if (err != 0) {
+            FAIL() << "Could not unpin the allowed_IPs map";
+            return;
+        }
 
         struct bpf_map *allowed_subnets_map = bpf_object__find_map_by_name(m_obj, "allowed_subnets");
-        bpf_map__unpin(allowed_subnets_map, bpf_map__get_pin_path(allowed_subnets_map));
+        if (!allowed_subnets_map)
+        {
+            FAIL() << "Could not find the allowed_subnets map";
+            return;
+        }
+        err = bpf_map__unpin(allowed_subnets_map, bpf_map__get_pin_path(allowed_subnets_map));
+        if (err != 0) {
+            FAIL() << "Could not unpin the allowed_subnets map";
+            return;
+        }
 
         bpf_object__close(m_obj);
         m_prog_fd = -1;

--- a/README.md
+++ b/README.md
@@ -41,14 +41,14 @@ Collection of BPF programs for Linux.
 **Usage**
 
 ```bash
-cd build/GPL/HostIsolation/TcFilter
-sudo ../TcFilter/BPFTcFilterTests
+cd build/target/ebpf
+sudo ../test/BPFTcFilterTests
 ```
 
 Or if you want to use a custom path for the eBPF object file.
 
 ```bash
-sudo ELASTIC_EBPF_TC_FILTER_OBJ_PATH=build/GPL/HostIsolation/TcFilter/TcFilter.bpf.o  build/GPL/HostIsolation/TcFilter/BPFTcFilterTest
+sudo ELASTIC_EBPF_TC_FILTER_OBJ_PATH=build/target/ebpf/TcFilter.bpf.o  build/target/test/BPFTcFilterTests
 ```
 
 ## Build
@@ -72,7 +72,9 @@ make
 Besides the usual CMake variables, you can set the following variables which are specific to this project.
 
 | Variable      | Description                                      |
+| ------------- | ------------------------------------------------ |
 | -DTARGET_DIR  | Directory to use to store the compiled targets   |
+
 
 ```
 target


### PR DESCRIPTION
Since the maps are pinned to the filesystem
the tests might be flaky if the maps are not cleared at every iteration.

This test could be made more pure by non pinning the map. However we
really want to test that behavior as well because we rely on pinning and
non pinned maps could behave differently because they have a different
lifecycle.