### PR TITLE
Format code and enforce code formatting in Jenkins

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,2 +1,6 @@
 ---
-DisableFormat: true
+BasedOnStyle: LLVM
+IndentWidth: 4
+BreakBeforeBraces: Linux
+BinPackParameters: false
+AlignConsecutiveAssignments: true

--- a/.clang-format
+++ b/.clang-format
@@ -10,3 +10,4 @@ SpaceBeforeParens: ControlStatements
 SpacesBeforeTrailingComments: 1
 UseTab: Never
 ColumnLimit: 100
+AllowShortFunctionsOnASingleLine: false

--- a/.clang-format
+++ b/.clang-format
@@ -4,3 +4,9 @@ IndentWidth: 4
 BreakBeforeBraces: Linux
 BinPackParameters: false
 AlignConsecutiveAssignments: true
+DerivePointerAlignment: false
+PointerAlignment: Right
+SpaceBeforeParens: ControlStatements
+SpacesBeforeTrailingComments: 1
+UseTab: Never
+ColumnLimit: 100

--- a/GPL/EventProbe/EventProbe.bpf.c
+++ b/GPL/EventProbe/EventProbe.bpf.c
@@ -17,13 +17,14 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
+#include "vmlinux.h"
+
 #include <bpf/bpf_core_read.h>
 #include <bpf/bpf_helpers.h>
 #include <bpf/bpf_tracing.h>
 
 #include "Helpers.h"
 #include "Maps.h"
-#include "vmlinux.h"
 
 char LICENSE[] SEC("license") = "GPL";
 

--- a/GPL/EventProbe/FileEvents.h
+++ b/GPL/EventProbe/FileEvents.h
@@ -23,8 +23,7 @@
 
 #include "EbpfEventProto.h"
 
-static int ebpf_file_path__from_dentry(struct ebpf_file_path *dst,
-                                       struct dentry *src)
+static int ebpf_file_path__from_dentry(struct ebpf_file_path *dst, struct dentry *src)
 {
     size_t filepart_length;
     struct dentry *parent_dentry  = NULL;
@@ -56,10 +55,9 @@ static int ebpf_file_path__from_dentry(struct ebpf_file_path *dst,
 
     int j = 0;
     for (int i = dentries_len; i != 0; i--) {
-        filepart_length = bpf_probe_read_kernel_str(
-            dst->path_array[j], MAX_PATH,
-            BPF_CORE_READ(dentries[i - 1], d_name.name));
-        j = j + 1;
+        filepart_length = bpf_probe_read_kernel_str(dst->path_array[j], MAX_PATH,
+                                                    BPF_CORE_READ(dentries[i - 1], d_name.name));
+        j               = j + 1;
     }
     dst->patharray_len = j;
     return j;

--- a/GPL/EventProbe/Helpers.h
+++ b/GPL/EventProbe/Helpers.h
@@ -21,15 +21,15 @@
 #ifndef EBPF_EVENTPROBE_HELPERS_H
 #define EBPF_EVENTPROBE_HELPERS_H
 
-#include "FileEvents.h"
 #include "EbpfEventProto.h"
+#include "FileEvents.h"
 
-static void ebpf_argv__fill(char *buf, size_t buf_size, const struct task_struct *task)
+ebpf_argv__fill(char *buf, size_t buf_size, const struct task_struct *task)
 {
     unsigned long start, end, size;
 
     start = task->mm->arg_start;
-    end = task->mm->arg_end;
+    end   = task->mm->arg_end;
 
     size = end - start;
     size = size > buf_size ? buf_size : size;
@@ -40,17 +40,19 @@ static void ebpf_argv__fill(char *buf, size_t buf_size, const struct task_struct
     buf[buf_size - 1] = '\0';
 }
 
-static void ebpf_ctty__fill(struct ebpf_tty_dev *ctty, const struct task_struct *task)
+static void ebpf_ctty__fill(struct ebpf_tty_dev *ctty,
+                            const struct task_struct *task)
 {
     ctty->major = task->signal->tty->driver->major;
     ctty->minor = task->signal->tty->driver->minor_start;
     ctty->minor += task->signal->tty->index;
 }
 
-static void ebpf_pid_info__fill(struct ebpf_pid_info *pi, const struct task_struct *task)
+static void ebpf_pid_info__fill(struct ebpf_pid_info *pi,
+                                const struct task_struct *task)
 {
     pi->tgid = task->tgid;
-    pi->sid = task->group_leader->signal->pids[PIDTYPE_SID]->numbers[0].nr;
+    pi->sid  = task->group_leader->signal->pids[PIDTYPE_SID]->numbers[0].nr;
 }
 
 static bool is_kernel_thread(const struct task_struct *task)

--- a/GPL/EventProbe/Helpers.h
+++ b/GPL/EventProbe/Helpers.h
@@ -24,7 +24,7 @@
 #include "EbpfEventProto.h"
 #include "FileEvents.h"
 
-ebpf_argv__fill(char *buf, size_t buf_size, const struct task_struct *task)
+static void ebpf_argv__fill(char *buf, size_t buf_size, const struct task_struct *task)
 {
     unsigned long start, end, size;
 
@@ -34,22 +34,20 @@ ebpf_argv__fill(char *buf, size_t buf_size, const struct task_struct *task)
     size = end - start;
     size = size > buf_size ? buf_size : size;
 
-    bpf_probe_read_user(buf, size, (void *) start);
+    bpf_probe_read_user(buf, size, (void *)start);
 
     // Prevent final arg from being unterminated if buf is too small for args
     buf[buf_size - 1] = '\0';
 }
 
-static void ebpf_ctty__fill(struct ebpf_tty_dev *ctty,
-                            const struct task_struct *task)
+static void ebpf_ctty__fill(struct ebpf_tty_dev *ctty, const struct task_struct *task)
 {
     ctty->major = task->signal->tty->driver->major;
     ctty->minor = task->signal->tty->driver->minor_start;
     ctty->minor += task->signal->tty->index;
 }
 
-static void ebpf_pid_info__fill(struct ebpf_pid_info *pi,
-                                const struct task_struct *task)
+static void ebpf_pid_info__fill(struct ebpf_pid_info *pi, const struct task_struct *task)
 {
     pi->tgid = task->tgid;
     pi->sid  = task->group_leader->signal->pids[PIDTYPE_SID]->numbers[0].nr;

--- a/GPL/EventProbe/Maps.h
+++ b/GPL/EventProbe/Maps.h
@@ -5,7 +5,7 @@
 // to be used instead of this one as the common parts evolve
 // to have a shared buffer between File, Network and Process.
 struct bpf_map_def SEC("maps") ringbuf = {
-    .type = BPF_MAP_TYPE_RINGBUF,
+    .type        = BPF_MAP_TYPE_RINGBUF,
     .max_entries = 4096 * 64, // todo: Need to verify if 256 kb is what we want
 };
 

--- a/GPL/HostIsolation/KprobeConnectHook/Kerneldefs.h
+++ b/GPL/HostIsolation/KprobeConnectHook/Kerneldefs.h
@@ -18,7 +18,6 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-
 typedef signed char __s8;
 
 typedef unsigned char __u8;
@@ -61,48 +60,47 @@ typedef __u64 __be64;
 
 typedef __u32 __wsum;
 
-
 struct in_addr {
-	__be32 s_addr;
+    __be32 s_addr;
 };
 
 typedef short unsigned int __kernel_sa_family_t;
 typedef __kernel_sa_family_t sa_family_t;
 
 struct sockaddr_in {
-	__kernel_sa_family_t sin_family;
-	__be16 sin_port;
-	struct in_addr sin_addr;
-	unsigned char __pad[8];
+    __kernel_sa_family_t sin_family;
+    __be16 sin_port;
+    struct in_addr sin_addr;
+    unsigned char __pad[8];
 };
 
 struct sockaddr {
-	sa_family_t sa_family;
-	char sa_data[14];
+    sa_family_t sa_family;
+    char sa_data[14];
 };
 
 struct pt_regs {
-	long unsigned int r15;
-	long unsigned int r14;
-	long unsigned int r13;
-	long unsigned int r12;
-	long unsigned int bp;
-	long unsigned int bx;
-	long unsigned int r11;
-	long unsigned int r10;
-	long unsigned int r9;
-	long unsigned int r8;
-	long unsigned int ax;
-	long unsigned int cx;
-	long unsigned int dx;
-	long unsigned int si;
-	long unsigned int di;
-	long unsigned int orig_ax;
-	long unsigned int ip;
-	long unsigned int cs;
-	long unsigned int flags;
-	long unsigned int sp;
-	long unsigned int ss;
+    long unsigned int r15;
+    long unsigned int r14;
+    long unsigned int r13;
+    long unsigned int r12;
+    long unsigned int bp;
+    long unsigned int bx;
+    long unsigned int r11;
+    long unsigned int r10;
+    long unsigned int r9;
+    long unsigned int r8;
+    long unsigned int ax;
+    long unsigned int cx;
+    long unsigned int dx;
+    long unsigned int si;
+    long unsigned int di;
+    long unsigned int orig_ax;
+    long unsigned int ip;
+    long unsigned int cs;
+    long unsigned int flags;
+    long unsigned int sp;
+    long unsigned int ss;
 };
 
 // from aarch64 ptrace.h:
@@ -110,8 +108,8 @@ struct pt_regs {
  * User structures for general purpose, floating point and debug registers.
  */
 struct user_pt_regs {
-    __u64       regs[31];
-    __u64       sp;
-    __u64       pc;
-    __u64       pstate;
+    __u64 regs[31];
+    __u64 sp;
+    __u64 pc;
+    __u64 pstate;
 };

--- a/GPL/HostIsolation/KprobeConnectHook/KprobeConnectHook.bpf.c
+++ b/GPL/HostIsolation/KprobeConnectHook/KprobeConnectHook.bpf.c
@@ -25,10 +25,11 @@
 // flag needed to pick the right PT_REGS macros in bpf_tracing.h
 #define __KERNEL__
 
+#include "Kerneldefs.h"
+
 #include <bpf/bpf_helpers.h>
 #include <bpf/bpf_tracing.h>
 
-#include "Kerneldefs.h"
 // taken from libbpf uapi include dir
 #include <linux/bpf.h>
 

--- a/GPL/HostIsolation/KprobeConnectHook/KprobeConnectHook.bpf.c
+++ b/GPL/HostIsolation/KprobeConnectHook/KprobeConnectHook.bpf.c
@@ -18,68 +18,63 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-
 // Host Isolation - this eBPF program hooks into tcp_v4_connect kprobe and adds
-// entries to the IP allowlist if an allowed process tries to initiate a connection.
+// entries to the IP allowlist if an allowed process tries to initiate a
+// connection.
 
 // flag needed to pick the right PT_REGS macros in bpf_tracing.h
 #define __KERNEL__
 
-#include "Kerneldefs.h"
 #include <bpf/bpf_helpers.h>
 #include <bpf/bpf_tracing.h>
+
+#include "Kerneldefs.h"
 // taken from libbpf uapi include dir
 #include <linux/bpf.h>
 
 // not to be defined in production builds
 //#define DEBUG_TRACE_PRINTK
 
-struct
-{
+struct {
     __uint(type, BPF_MAP_TYPE_HASH);
     __uint(key_size, sizeof(u32));
     __uint(value_size, sizeof(u32));
     __uint(max_entries, 512);
 } allowed_IPs SEC(".maps");
 
-struct
-{
+struct {
     __uint(type, BPF_MAP_TYPE_HASH);
     __uint(key_size, sizeof(u32));
     __uint(value_size, sizeof(u32));
     __uint(max_entries, 128);
 } allowed_pids SEC(".maps");
 
-static __always_inline void
-add_IP_to_allowlist(__u32 daddr)
+static __always_inline void add_IP_to_allowlist(__u32 daddr)
 {
     // add new entry
     u32 val = 1;
     long rv = bpf_map_update_elem(&allowed_IPs, &daddr, &val, BPF_ANY);
 #ifdef DEBUG_TRACE_PRINTK
-    if (rv)
-    {
+    if (rv) {
         bpf_printk("Error updating hashmap\n");
     }
 #endif
 }
 
-static __always_inline int
-enter_tcp_connect(struct sockaddr *uaddr)
+static __always_inline int enter_tcp_connect(struct sockaddr *uaddr)
 {
     __u64 pid_tgid = bpf_get_current_pid_tgid();
-    __u32 tgid = pid_tgid >> 32;
-    __u32 *elem = NULL;
-    __u32 daddr = 0;
+    __u32 tgid     = pid_tgid >> 32;
+    __u32 *elem    = NULL;
+    __u32 daddr    = 0;
 
-    struct sockaddr_in *sin = (struct sockaddr_in*)uaddr;
+    struct sockaddr_in *sin = (struct sockaddr_in *)uaddr;
     bpf_probe_read(&daddr, sizeof(daddr), &sin->sin_addr.s_addr);
 
     // check if tgid (userspace PID) is allowed
     elem = bpf_map_lookup_elem(&allowed_pids, &tgid);
 
-    if (elem)
-    {
+    if (elem) {
         // tgid (userspace PID) is allowed, add destination IP to IP allowlist
         add_IP_to_allowlist(daddr);
     }
@@ -91,11 +86,9 @@ enter_tcp_connect(struct sockaddr *uaddr)
 // BPF_KPROBE uses PT_REGS_PARM2 macro underneath to get the arg
 // define ARCH env var so that it gets the argument from the right register
 SEC("kprobe/tcp_v4_connect")
-int
-BPF_KPROBE(tcp_v4_connect, void *sk, struct sockaddr *uaddr)
+int BPF_KPROBE(tcp_v4_connect, void *sk, struct sockaddr *uaddr)
 {
     return enter_tcp_connect(uaddr);
 }
 
 char LICENSE[] SEC("license") = "GPL";
-

--- a/GPL/HostIsolation/TcFilter/Kerneldefs.h
+++ b/GPL/HostIsolation/TcFilter/Kerneldefs.h
@@ -18,7 +18,6 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-
 typedef signed char __s8;
 
 typedef unsigned char __u8;
@@ -61,7 +60,6 @@ typedef __u64 __be64;
 
 typedef __u32 __wsum;
 
-
 #ifdef __CHECKER__
 #define __bitwise__ __attribute__((bitwise))
 #else
@@ -79,60 +77,59 @@ typedef __u64 __bitwise __be64;
 typedef __u16 __bitwise __sum16;
 typedef __u32 __bitwise __wsum;
 
-
 /* Standard well-defined IP protocols.  */
 enum {
-  IPPROTO_IP = 0,               /* Dummy protocol for TCP               */
-#define IPPROTO_IP              IPPROTO_IP
-  IPPROTO_ICMP = 1,             /* Internet Control Message Protocol    */
-#define IPPROTO_ICMP            IPPROTO_ICMP
-  IPPROTO_IGMP = 2,             /* Internet Group Management Protocol   */
-#define IPPROTO_IGMP            IPPROTO_IGMP
-  IPPROTO_IPIP = 4,             /* IPIP tunnels (older KA9Q tunnels use 94) */
-#define IPPROTO_IPIP            IPPROTO_IPIP
-  IPPROTO_TCP = 6,              /* Transmission Control Protocol        */
-#define IPPROTO_TCP             IPPROTO_TCP
-  IPPROTO_EGP = 8,              /* Exterior Gateway Protocol            */
-#define IPPROTO_EGP             IPPROTO_EGP
-  IPPROTO_PUP = 12,             /* PUP protocol                         */
-#define IPPROTO_PUP             IPPROTO_PUP
-  IPPROTO_UDP = 17,             /* User Datagram Protocol               */
-#define IPPROTO_UDP             IPPROTO_UDP
-  IPPROTO_IDP = 22,             /* XNS IDP protocol                     */
-#define IPPROTO_IDP             IPPROTO_IDP
-  IPPROTO_TP = 29,              /* SO Transport Protocol Class 4        */
-#define IPPROTO_TP              IPPROTO_TP
-  IPPROTO_DCCP = 33,            /* Datagram Congestion Control Protocol */
-#define IPPROTO_DCCP            IPPROTO_DCCP
-  IPPROTO_IPV6 = 41,            /* IPv6-in-IPv4 tunnelling              */
-#define IPPROTO_IPV6            IPPROTO_IPV6
-  IPPROTO_RSVP = 46,            /* RSVP Protocol                        */
-#define IPPROTO_RSVP            IPPROTO_RSVP
-  IPPROTO_GRE = 47,             /* Cisco GRE tunnels (rfc 1701,1702)    */
-#define IPPROTO_GRE             IPPROTO_GRE
-  IPPROTO_ESP = 50,             /* Encapsulation Security Payload protocol */
-#define IPPROTO_ESP             IPPROTO_ESP
-  IPPROTO_AH = 51,              /* Authentication Header protocol       */
-#define IPPROTO_AH              IPPROTO_AH
-  IPPROTO_MTP = 92,             /* Multicast Transport Protocol         */
-#define IPPROTO_MTP             IPPROTO_MTP
-  IPPROTO_BEETPH = 94,          /* IP option pseudo header for BEET     */
-#define IPPROTO_BEETPH          IPPROTO_BEETPH
-  IPPROTO_ENCAP = 98,           /* Encapsulation Header                 */
-#define IPPROTO_ENCAP           IPPROTO_ENCAP
-  IPPROTO_PIM = 103,            /* Protocol Independent Multicast       */
-#define IPPROTO_PIM             IPPROTO_PIM
-  IPPROTO_COMP = 108,           /* Compression Header Protocol          */
-#define IPPROTO_COMP            IPPROTO_COMP
-  IPPROTO_SCTP = 132,           /* Stream Control Transport Protocol    */
-#define IPPROTO_SCTP            IPPROTO_SCTP
-  IPPROTO_UDPLITE = 136,        /* UDP-Lite (RFC 3828)                  */
-#define IPPROTO_UDPLITE         IPPROTO_UDPLITE
-  IPPROTO_MPLS = 137,           /* MPLS in IP (RFC 4023)                */
-#define IPPROTO_MPLS            IPPROTO_MPLS
-  IPPROTO_RAW = 255,            /* Raw IP packets                       */
-#define IPPROTO_RAW             IPPROTO_RAW
-  IPPROTO_MAX
+    IPPROTO_IP = 0, /* Dummy protocol for TCP               */
+#define IPPROTO_IP IPPROTO_IP
+    IPPROTO_ICMP = 1, /* Internet Control Message Protocol    */
+#define IPPROTO_ICMP IPPROTO_ICMP
+    IPPROTO_IGMP = 2, /* Internet Group Management Protocol   */
+#define IPPROTO_IGMP IPPROTO_IGMP
+    IPPROTO_IPIP = 4, /* IPIP tunnels (older KA9Q tunnels use 94) */
+#define IPPROTO_IPIP IPPROTO_IPIP
+    IPPROTO_TCP = 6, /* Transmission Control Protocol        */
+#define IPPROTO_TCP IPPROTO_TCP
+    IPPROTO_EGP = 8, /* Exterior Gateway Protocol            */
+#define IPPROTO_EGP IPPROTO_EGP
+    IPPROTO_PUP = 12, /* PUP protocol                         */
+#define IPPROTO_PUP IPPROTO_PUP
+    IPPROTO_UDP = 17, /* User Datagram Protocol               */
+#define IPPROTO_UDP IPPROTO_UDP
+    IPPROTO_IDP = 22, /* XNS IDP protocol                     */
+#define IPPROTO_IDP IPPROTO_IDP
+    IPPROTO_TP = 29, /* SO Transport Protocol Class 4        */
+#define IPPROTO_TP IPPROTO_TP
+    IPPROTO_DCCP = 33, /* Datagram Congestion Control Protocol */
+#define IPPROTO_DCCP IPPROTO_DCCP
+    IPPROTO_IPV6 = 41, /* IPv6-in-IPv4 tunnelling              */
+#define IPPROTO_IPV6 IPPROTO_IPV6
+    IPPROTO_RSVP = 46, /* RSVP Protocol                        */
+#define IPPROTO_RSVP IPPROTO_RSVP
+    IPPROTO_GRE = 47, /* Cisco GRE tunnels (rfc 1701,1702)    */
+#define IPPROTO_GRE IPPROTO_GRE
+    IPPROTO_ESP = 50, /* Encapsulation Security Payload protocol */
+#define IPPROTO_ESP IPPROTO_ESP
+    IPPROTO_AH = 51, /* Authentication Header protocol       */
+#define IPPROTO_AH IPPROTO_AH
+    IPPROTO_MTP = 92, /* Multicast Transport Protocol         */
+#define IPPROTO_MTP IPPROTO_MTP
+    IPPROTO_BEETPH = 94, /* IP option pseudo header for BEET     */
+#define IPPROTO_BEETPH IPPROTO_BEETPH
+    IPPROTO_ENCAP = 98, /* Encapsulation Header                 */
+#define IPPROTO_ENCAP IPPROTO_ENCAP
+    IPPROTO_PIM = 103, /* Protocol Independent Multicast       */
+#define IPPROTO_PIM IPPROTO_PIM
+    IPPROTO_COMP = 108, /* Compression Header Protocol          */
+#define IPPROTO_COMP IPPROTO_COMP
+    IPPROTO_SCTP = 132, /* Stream Control Transport Protocol    */
+#define IPPROTO_SCTP IPPROTO_SCTP
+    IPPROTO_UDPLITE = 136, /* UDP-Lite (RFC 3828)                  */
+#define IPPROTO_UDPLITE IPPROTO_UDPLITE
+    IPPROTO_MPLS = 137, /* MPLS in IP (RFC 4023)                */
+#define IPPROTO_MPLS IPPROTO_MPLS
+    IPPROTO_RAW = 255, /* Raw IP packets                       */
+#define IPPROTO_RAW IPPROTO_RAW
+    IPPROTO_MAX
 };
 
 /*
@@ -140,143 +137,153 @@ enum {
  *      and FCS/CRC (frame check sequence).
  */
 
-#define ETH_ALEN        6               /* Octets in one ethernet addr   */
-#define ETH_TLEN        2               /* Octets in ethernet type field */
-#define ETH_HLEN        14              /* Total octets in header.       */
-#define ETH_ZLEN        60              /* Min. octets in frame sans FCS */
-#define ETH_DATA_LEN    1500            /* Max. octets in payload        */
-#define ETH_FRAME_LEN   1514            /* Max. octets in frame sans FCS */
-#define ETH_FCS_LEN     4               /* Octets in the FCS             */
+#define ETH_ALEN 6         /* Octets in one ethernet addr   */
+#define ETH_TLEN 2         /* Octets in ethernet type field */
+#define ETH_HLEN 14        /* Total octets in header.       */
+#define ETH_ZLEN 60        /* Min. octets in frame sans FCS */
+#define ETH_DATA_LEN 1500  /* Max. octets in payload        */
+#define ETH_FRAME_LEN 1514 /* Max. octets in frame sans FCS */
+#define ETH_FCS_LEN 4      /* Octets in the FCS             */
 
-#define ETH_MIN_MTU     68              /* Min IPv4 MTU per RFC791      */
-#define ETH_MAX_MTU     0xFFFFU         /* 65535, same as IP_MAX_MTU    */
+#define ETH_MIN_MTU 68      /* Min IPv4 MTU per RFC791      */
+#define ETH_MAX_MTU 0xFFFFU /* 65535, same as IP_MAX_MTU    */
 
 /*
  *      These are the defined Ethernet Protocol ID's.
  */
 
-#define ETH_P_LOOP      0x0060          /* Ethernet Loopback packet     */
-#define ETH_P_PUP       0x0200          /* Xerox PUP packet             */
-#define ETH_P_PUPAT     0x0201          /* Xerox PUP Addr Trans packet  */
-#define ETH_P_TSN       0x22F0          /* TSN (IEEE 1722) packet       */
-#define ETH_P_IP        0x0800          /* Internet Protocol packet     */
-#define ETH_P_X25       0x0805          /* CCITT X.25                   */
-#define ETH_P_ARP       0x0806          /* Address Resolution packet    */
-#define ETH_P_BPQ       0x08FF          /* G8BPQ AX.25 Ethernet Packet  [ NOT AN OFFICIALLY REGISTERED ID ] */
-#define ETH_P_IEEEPUP   0x0a00          /* Xerox IEEE802.3 PUP packet */
-#define ETH_P_IEEEPUPAT 0x0a01          /* Xerox IEEE802.3 PUP Addr Trans packet */
-#define ETH_P_BATMAN    0x4305          /* B.A.T.M.A.N.-Advanced packet [ NOT AN OFFICIALLY REGISTERED ID ] */
-#define ETH_P_DEC       0x6000          /* DEC Assigned proto           */
-#define ETH_P_DNA_DL    0x6001          /* DEC DNA Dump/Load            */
-#define ETH_P_DNA_RC    0x6002          /* DEC DNA Remote Console       */
-#define ETH_P_DNA_RT    0x6003          /* DEC DNA Routing              */
-#define ETH_P_LAT       0x6004          /* DEC LAT                      */
-#define ETH_P_DIAG      0x6005          /* DEC Diagnostics              */
-#define ETH_P_CUST      0x6006          /* DEC Customer use             */
-#define ETH_P_SCA       0x6007          /* DEC Systems Comms Arch       */
-#define ETH_P_TEB       0x6558          /* Trans Ether Bridging         */
-#define ETH_P_RARP      0x8035          /* Reverse Addr Res packet      */
-#define ETH_P_ATALK     0x809B          /* Appletalk DDP                */
-#define ETH_P_AARP      0x80F3          /* Appletalk AARP               */
-#define ETH_P_8021Q     0x8100          /* 802.1Q VLAN Extended Header  */
-#define ETH_P_ERSPAN    0x88BE          /* ERSPAN type II               */
-#define ETH_P_IPX       0x8137          /* IPX over DIX                 */
-#define ETH_P_IPV6      0x86DD          /* IPv6 over bluebook           */
-#define ETH_P_PAUSE     0x8808          /* IEEE Pause frames. See 802.3 31B */
-#define ETH_P_SLOW      0x8809          /* Slow Protocol. See 802.3ad 43B */
-#define ETH_P_WCCP      0x883E          /* Web-cache coordination protocol
-                                         * defined in draft-wilson-wrec-wccp-v2-00.txt */
-#define ETH_P_MPLS_UC   0x8847          /* MPLS Unicast traffic         */
-#define ETH_P_MPLS_MC   0x8848          /* MPLS Multicast traffic       */
-#define ETH_P_ATMMPOA   0x884c          /* MultiProtocol Over ATM       */
-#define ETH_P_PPP_DISC  0x8863          /* PPPoE discovery messages     */
-#define ETH_P_PPP_SES   0x8864          /* PPPoE session messages       */
-#define ETH_P_LINK_CTL  0x886c          /* HPNA, wlan link local tunnel */
-#define ETH_P_ATMFATE   0x8884          /* Frame-based ATM Transport
-                                         * over Ethernet
-                                         */
-#define ETH_P_PAE       0x888E          /* Port Access Entity (IEEE 802.1X) */
-#define ETH_P_AOE       0x88A2          /* ATA over Ethernet            */
-#define ETH_P_8021AD    0x88A8          /* 802.1ad Service VLAN         */
-#define ETH_P_802_EX1   0x88B5          /* 802.1 Local Experimental 1.  */
-#define ETH_P_TIPC      0x88CA          /* TIPC                         */
-#define ETH_P_MACSEC    0x88E5          /* 802.1ae MACsec */
-#define ETH_P_8021AH    0x88E7          /* 802.1ah Backbone Service Tag */
-#define ETH_P_MVRP      0x88F5          /* 802.1Q MVRP                  */
-#define ETH_P_1588      0x88F7          /* IEEE 1588 Timesync */
-#define ETH_P_NCSI      0x88F8          /* NCSI protocol                */
-#define ETH_P_PRP       0x88FB          /* IEC 62439-3 PRP/HSRv0        */
-#define ETH_P_FCOE      0x8906          /* Fibre Channel over Ethernet  */
-#define ETH_P_IBOE      0x8915          /* Infiniband over Ethernet     */
-#define ETH_P_TDLS      0x890D          /* TDLS */
-#define ETH_P_FIP       0x8914          /* FCoE Initialization Protocol */
-#define ETH_P_80221     0x8917          /* IEEE 802.21 Media Independent Handover Protocol */
-#define ETH_P_HSR       0x892F          /* IEC 62439-3 HSRv1    */
-#define ETH_P_NSH       0x894F          /* Network Service Header */
-#define ETH_P_LOOPBACK  0x9000          /* Ethernet loopback packet, per IEEE 802.3 */
-#define ETH_P_QINQ1     0x9100          /* deprecated QinQ VLAN [ NOT AN OFFICIALLY REGISTERED ID ] */
-#define ETH_P_QINQ2     0x9200          /* deprecated QinQ VLAN [ NOT AN OFFICIALLY REGISTERED ID ] */
-#define ETH_P_QINQ3     0x9300          /* deprecated QinQ VLAN [ NOT AN OFFICIALLY REGISTERED ID ] */
-#define ETH_P_EDSA      0xDADA          /* Ethertype DSA [ NOT AN OFFICIALLY REGISTERED ID ] */
-#define ETH_P_IFE       0xED3E          /* ForCES inter-FE LFB type */
-#define ETH_P_AF_IUCV   0xFBFB          /* IBM af_iucv [ NOT AN OFFICIALLY REGISTERED ID ] */
+#define ETH_P_LOOP 0x0060  /* Ethernet Loopback packet     */
+#define ETH_P_PUP 0x0200   /* Xerox PUP packet             */
+#define ETH_P_PUPAT 0x0201 /* Xerox PUP Addr Trans packet  */
+#define ETH_P_TSN 0x22F0   /* TSN (IEEE 1722) packet       */
+#define ETH_P_IP 0x0800    /* Internet Protocol packet     */
+#define ETH_P_X25 0x0805   /* CCITT X.25                   */
+#define ETH_P_ARP 0x0806   /* Address Resolution packet    */
+#define ETH_P_BPQ                                                              \
+    0x08FF /* G8BPQ AX.25 Ethernet Packet  [ NOT AN OFFICIALLY REGISTERED ID ] \
+            */
+#define ETH_P_IEEEPUP 0x0a00   /* Xerox IEEE802.3 PUP packet */
+#define ETH_P_IEEEPUPAT 0x0a01 /* Xerox IEEE802.3 PUP Addr Trans packet */
+#define ETH_P_BATMAN                                                           \
+    0x4305 /* B.A.T.M.A.N.-Advanced packet [ NOT AN OFFICIALLY REGISTERED ID ] \
+            */
+#define ETH_P_DEC 0x6000    /* DEC Assigned proto           */
+#define ETH_P_DNA_DL 0x6001 /* DEC DNA Dump/Load            */
+#define ETH_P_DNA_RC 0x6002 /* DEC DNA Remote Console       */
+#define ETH_P_DNA_RT 0x6003 /* DEC DNA Routing              */
+#define ETH_P_LAT 0x6004    /* DEC LAT                      */
+#define ETH_P_DIAG 0x6005   /* DEC Diagnostics              */
+#define ETH_P_CUST 0x6006   /* DEC Customer use             */
+#define ETH_P_SCA 0x6007    /* DEC Systems Comms Arch       */
+#define ETH_P_TEB 0x6558    /* Trans Ether Bridging         */
+#define ETH_P_RARP 0x8035   /* Reverse Addr Res packet      */
+#define ETH_P_ATALK 0x809B  /* Appletalk DDP                */
+#define ETH_P_AARP 0x80F3   /* Appletalk AARP               */
+#define ETH_P_8021Q 0x8100  /* 802.1Q VLAN Extended Header  */
+#define ETH_P_ERSPAN 0x88BE /* ERSPAN type II               */
+#define ETH_P_IPX 0x8137    /* IPX over DIX                 */
+#define ETH_P_IPV6 0x86DD   /* IPv6 over bluebook           */
+#define ETH_P_PAUSE 0x8808  /* IEEE Pause frames. See 802.3 31B */
+#define ETH_P_SLOW 0x8809   /* Slow Protocol. See 802.3ad 43B */
+#define ETH_P_WCCP                                                             \
+    0x883E                    /* Web-cache coordination protocol               \
+                               * defined in draft-wilson-wrec-wccp-v2-00.txt */
+#define ETH_P_MPLS_UC 0x8847  /* MPLS Unicast traffic         */
+#define ETH_P_MPLS_MC 0x8848  /* MPLS Multicast traffic       */
+#define ETH_P_ATMMPOA 0x884c  /* MultiProtocol Over ATM       */
+#define ETH_P_PPP_DISC 0x8863 /* PPPoE discovery messages     */
+#define ETH_P_PPP_SES 0x8864  /* PPPoE session messages       */
+#define ETH_P_LINK_CTL 0x886c /* HPNA, wlan link local tunnel */
+#define ETH_P_ATMFATE                                                          \
+    0x8884                   /* Frame-based ATM Transport                      \
+                              * over Ethernet                                  \
+                              */
+#define ETH_P_PAE 0x888E     /* Port Access Entity (IEEE 802.1X) */
+#define ETH_P_AOE 0x88A2     /* ATA over Ethernet            */
+#define ETH_P_8021AD 0x88A8  /* 802.1ad Service VLAN         */
+#define ETH_P_802_EX1 0x88B5 /* 802.1 Local Experimental 1.  */
+#define ETH_P_TIPC 0x88CA    /* TIPC                         */
+#define ETH_P_MACSEC 0x88E5  /* 802.1ae MACsec */
+#define ETH_P_8021AH 0x88E7  /* 802.1ah Backbone Service Tag */
+#define ETH_P_MVRP 0x88F5    /* 802.1Q MVRP                  */
+#define ETH_P_1588 0x88F7    /* IEEE 1588 Timesync */
+#define ETH_P_NCSI 0x88F8    /* NCSI protocol                */
+#define ETH_P_PRP 0x88FB     /* IEC 62439-3 PRP/HSRv0        */
+#define ETH_P_FCOE 0x8906    /* Fibre Channel over Ethernet  */
+#define ETH_P_IBOE 0x8915    /* Infiniband over Ethernet     */
+#define ETH_P_TDLS 0x890D    /* TDLS */
+#define ETH_P_FIP 0x8914     /* FCoE Initialization Protocol */
+#define ETH_P_80221                                                            \
+    0x8917               /* IEEE 802.21 Media Independent Handover Protocol    \
+                          */
+#define ETH_P_HSR 0x892F /* IEC 62439-3 HSRv1    */
+#define ETH_P_NSH 0x894F /* Network Service Header */
+#define ETH_P_LOOPBACK 0x9000 /* Ethernet loopback packet, per IEEE 802.3 */
+#define ETH_P_QINQ1                                                            \
+    0x9100 /* deprecated QinQ VLAN [ NOT AN OFFICIALLY REGISTERED ID ] */
+#define ETH_P_QINQ2                                                            \
+    0x9200 /* deprecated QinQ VLAN [ NOT AN OFFICIALLY REGISTERED ID ] */
+#define ETH_P_QINQ3                                                            \
+    0x9300 /* deprecated QinQ VLAN [ NOT AN OFFICIALLY REGISTERED ID ] */
+#define ETH_P_EDSA                                                             \
+    0xDADA               /* Ethertype DSA [ NOT AN OFFICIALLY REGISTERED ID ] */
+#define ETH_P_IFE 0xED3E /* ForCES inter-FE LFB type */
+#define ETH_P_AF_IUCV                                                          \
+    0xFBFB /* IBM af_iucv [ NOT AN OFFICIALLY REGISTERED ID ] */
 
-#define ETH_P_802_3_MIN 0x0600          /* If the value in the ethernet type is less than this value
-                                         * then the frame is Ethernet II. Else it is 802.3 */
+#define ETH_P_802_3_MIN                                                        \
+    0x0600 /* If the value in the ethernet type is less than this value        \
+            * then the frame is Ethernet II. Else it is 802.3 */
 
+#define TC_ACT_UNSPEC (-1)
+#define TC_ACT_OK 0
+#define TC_ACT_RECLASSIFY 1
+#define TC_ACT_SHOT 2
+#define TC_ACT_PIPE 3
+#define TC_ACT_STOLEN 4
+#define TC_ACT_QUEUED 5
+#define TC_ACT_REPEAT 6
+#define TC_ACT_REDIRECT 7
+#define TC_ACT_JUMP 0x10000000
 
-#define TC_ACT_UNSPEC	(-1)
-#define TC_ACT_OK		0
-#define TC_ACT_RECLASSIFY	1
-#define TC_ACT_SHOT		2
-#define TC_ACT_PIPE		3
-#define TC_ACT_STOLEN		4
-#define TC_ACT_QUEUED		5
-#define TC_ACT_REPEAT		6
-#define TC_ACT_REDIRECT		7
-#define TC_ACT_JUMP		0x10000000
-
-
-//TODO change to compiler flag ?
+// TODO change to compiler flag ?
 #define __LITTLE_ENDIAN_BITFIELD
 
 struct iphdr {
 #if defined(__LITTLE_ENDIAN_BITFIELD)
-	__u8	ihl:4,
-		version:4;
-#elif defined (__BIG_ENDIAN_BITFIELD)
-	__u8	version:4,
-  		ihl:4;
+    __u8 ihl : 4, version : 4;
+#elif defined(__BIG_ENDIAN_BITFIELD)
+    __u8 version : 4, ihl : 4;
 #else
-#error	"Please fix <asm/byteorder.h>"
+#error "Please fix <asm/byteorder.h>"
 #endif
-	__u8	tos;
-	__be16	tot_len;
-	__be16	id;
-	__be16	frag_off;
-	__u8	ttl;
-	__u8	protocol;
-	__sum16	check;
-	__be32	saddr;
-	__be32	daddr;
-	/*The options start here. */
+    __u8 tos;
+    __be16 tot_len;
+    __be16 id;
+    __be16 frag_off;
+    __u8 ttl;
+    __u8 protocol;
+    __sum16 check;
+    __be32 saddr;
+    __be32 daddr;
+    /*The options start here. */
 };
 
 #define __UAPI_DEF_IN6_ADDR 1
 
 #if __UAPI_DEF_IN6_ADDR
 struct in6_addr {
-	union {
-		__u8		u6_addr8[16];
+    union {
+        __u8 u6_addr8[16];
 #if __UAPI_DEF_IN6_ADDR_ALT
-		__be16		u6_addr16[8];
-		__be32		u6_addr32[4];
+        __be16 u6_addr16[8];
+        __be32 u6_addr32[4];
 #endif
-	} in6_u;
-#define s6_addr			in6_u.u6_addr8
+    } in6_u;
+#define s6_addr in6_u.u6_addr8
 #if __UAPI_DEF_IN6_ADDR_ALT
-#define s6_addr16		in6_u.u6_addr16
-#define s6_addr32		in6_u.u6_addr32
+#define s6_addr16 in6_u.u6_addr16
+#define s6_addr32 in6_u.u6_addr32
 #endif
 };
 
@@ -284,128 +291,110 @@ struct in6_addr {
 
 struct ipv6hdr {
 #if defined(__LITTLE_ENDIAN_BITFIELD)
-	__u8			priority:4,
-				version:4;
+    __u8 priority : 4, version : 4;
 #elif defined(__BIG_ENDIAN_BITFIELD)
-	__u8			version:4,
-				priority:4;
+    __u8 version : 4, priority : 4;
 #else
-#error	"Please fix <asm/byteorder.h>"
+#error "Please fix <asm/byteorder.h>"
 #endif
-	__u8			flow_lbl[3];
+    __u8 flow_lbl[3];
 
-	__be16			payload_len;
-	__u8			nexthdr;
-	__u8			hop_limit;
+    __be16 payload_len;
+    __u8 nexthdr;
+    __u8 hop_limit;
 
-	struct	in6_addr	saddr;
-	struct	in6_addr	daddr;
+    struct in6_addr saddr;
+    struct in6_addr daddr;
 };
 
 struct udphdr {
-        __be16  source;
-        __be16  dest;
-        __be16  len;
-        __sum16 check;
+    __be16 source;
+    __be16 dest;
+    __be16 len;
+    __sum16 check;
 };
 
 struct tcphdr {
-        __be16  source;
-        __be16  dest;
-        __be32  seq;
-        __be32  ack_seq;
+    __be16 source;
+    __be16 dest;
+    __be32 seq;
+    __be32 ack_seq;
 #if defined(__LITTLE_ENDIAN_BITFIELD)
-        __u16   res1:4,
-                doff:4,
-                fin:1,
-                syn:1,
-                rst:1,
-                psh:1,
-                ack:1,
-                urg:1,
-                ece:1,
-                cwr:1;
+    __u16 res1 : 4, doff : 4, fin : 1, syn : 1, rst : 1, psh : 1, ack : 1,
+        urg : 1, ece : 1, cwr : 1;
 #elif defined(__BIG_ENDIAN_BITFIELD)
-        __u16   doff:4,
-                res1:4,
-                cwr:1,
-                ece:1,
-                urg:1,
-                ack:1,
-                psh:1,
-                rst:1,
-                syn:1,
-                fin:1;
+    __u16 doff : 4, res1 : 4, cwr : 1, ece : 1, urg : 1, ack : 1, psh : 1,
+        rst : 1, syn : 1, fin : 1;
 #else
-#error  "Adjust your <asm/byteorder.h> defines"
-#endif  
-        __be16  window;
-        __sum16 check;
-        __be16  urg_ptr;
+#error "Adjust your <asm/byteorder.h> defines"
+#endif
+    __be16 window;
+    __sum16 check;
+    __be16 urg_ptr;
 };
 
 struct ethhdr {
-	unsigned char	h_dest[ETH_ALEN];	/* destination eth addr	*/
-	unsigned char	h_source[ETH_ALEN];	/* source ether addr	*/
-	__be16		h_proto;		/* packet type ID field	*/
+    unsigned char h_dest[ETH_ALEN];   /* destination eth addr	*/
+    unsigned char h_source[ETH_ALEN]; /* source ether addr	*/
+    __be16 h_proto;                   /* packet type ID field	*/
 } __attribute__((packed));
 
-// This header might be included in userspace programs (e.g BPFTcFilterTests.cpp)
-// where we want to share some definitions with kernel space programs (TcFilter.bpf.c).
-// In this case, we need to gate some specific kernel definitions that are not needed in userspace.
+// This header might be included in userspace programs (e.g
+// BPFTcFilterTests.cpp) where we want to share some definitions with kernel
+// space programs (TcFilter.bpf.c). In this case, we need to gate some specific
+// kernel definitions that are not needed in userspace.
 #ifdef __KERNEL__
 enum bpf_map_type {
-	BPF_MAP_TYPE_UNSPEC,
-	BPF_MAP_TYPE_HASH,
-	BPF_MAP_TYPE_ARRAY,
-	BPF_MAP_TYPE_PROG_ARRAY,
-	BPF_MAP_TYPE_PERF_EVENT_ARRAY,
-	BPF_MAP_TYPE_PERCPU_HASH,
-	BPF_MAP_TYPE_PERCPU_ARRAY,
-	BPF_MAP_TYPE_STACK_TRACE,
-	BPF_MAP_TYPE_CGROUP_ARRAY,
-	BPF_MAP_TYPE_LRU_HASH,
-	BPF_MAP_TYPE_LRU_PERCPU_HASH,
-	BPF_MAP_TYPE_LPM_TRIE,
-	BPF_MAP_TYPE_ARRAY_OF_MAPS,
-	BPF_MAP_TYPE_HASH_OF_MAPS,
-	BPF_MAP_TYPE_DEVMAP,
-	BPF_MAP_TYPE_SOCKMAP,
-	BPF_MAP_TYPE_CPUMAP,
+    BPF_MAP_TYPE_UNSPEC,
+    BPF_MAP_TYPE_HASH,
+    BPF_MAP_TYPE_ARRAY,
+    BPF_MAP_TYPE_PROG_ARRAY,
+    BPF_MAP_TYPE_PERF_EVENT_ARRAY,
+    BPF_MAP_TYPE_PERCPU_HASH,
+    BPF_MAP_TYPE_PERCPU_ARRAY,
+    BPF_MAP_TYPE_STACK_TRACE,
+    BPF_MAP_TYPE_CGROUP_ARRAY,
+    BPF_MAP_TYPE_LRU_HASH,
+    BPF_MAP_TYPE_LRU_PERCPU_HASH,
+    BPF_MAP_TYPE_LPM_TRIE,
+    BPF_MAP_TYPE_ARRAY_OF_MAPS,
+    BPF_MAP_TYPE_HASH_OF_MAPS,
+    BPF_MAP_TYPE_DEVMAP,
+    BPF_MAP_TYPE_SOCKMAP,
+    BPF_MAP_TYPE_CPUMAP,
 };
 struct __sk_buff {
-	__u32 len;
-	__u32 pkt_type;
-	__u32 mark;
-	__u32 queue_mapping;
-	__u32 protocol;
-	__u32 vlan_present;
-	__u32 vlan_tci;
-	__u32 vlan_proto;
-	__u32 priority;
-	__u32 ingress_ifindex;
-	__u32 ifindex;
-	__u32 tc_index;
-	__u32 cb[5];
-	__u32 hash;
-	__u32 tc_classid;
-	__u32 data;
-	__u32 data_end;
-	__u32 napi_id;
+    __u32 len;
+    __u32 pkt_type;
+    __u32 mark;
+    __u32 queue_mapping;
+    __u32 protocol;
+    __u32 vlan_present;
+    __u32 vlan_tci;
+    __u32 vlan_proto;
+    __u32 priority;
+    __u32 ingress_ifindex;
+    __u32 ifindex;
+    __u32 tc_index;
+    __u32 cb[5];
+    __u32 hash;
+    __u32 tc_classid;
+    __u32 data;
+    __u32 data_end;
+    __u32 napi_id;
 
-	/* Accessed by BPF_PROG_TYPE_sk_skb types from here to ... */
-	__u32 family;
-	__u32 remote_ip4;	/* Stored in network byte order */
-	__u32 local_ip4;	/* Stored in network byte order */
-	__u32 remote_ip6[4];	/* Stored in network byte order */
-	__u32 local_ip6[4];	/* Stored in network byte order */
-	__u32 remote_port;	/* Stored in network byte order */
-	__u32 local_port;	/* stored in host byte order */
-	/* ... here. */
-	
-	// Note: there are more fields but we don't use them
+    /* Accessed by BPF_PROG_TYPE_sk_skb types from here to ... */
+    __u32 family;
+    __u32 remote_ip4;    /* Stored in network byte order */
+    __u32 local_ip4;     /* Stored in network byte order */
+    __u32 remote_ip6[4]; /* Stored in network byte order */
+    __u32 local_ip6[4];  /* Stored in network byte order */
+    __u32 remote_port;   /* Stored in network byte order */
+    __u32 local_port;    /* stored in host byte order */
+                         /* ... here. */
+
+    // Note: there are more fields but we don't use them
 };
 #else
 #define __aligned_u64 __u64 __attribute__((aligned(8)))
 #endif // __KERNEL__
-

--- a/GPL/HostIsolation/TcFilter/Kerneldefs.h
+++ b/GPL/HostIsolation/TcFilter/Kerneldefs.h
@@ -159,14 +159,14 @@ enum {
 #define ETH_P_IP 0x0800    /* Internet Protocol packet     */
 #define ETH_P_X25 0x0805   /* CCITT X.25                   */
 #define ETH_P_ARP 0x0806   /* Address Resolution packet    */
-#define ETH_P_BPQ                                                              \
-    0x08FF /* G8BPQ AX.25 Ethernet Packet  [ NOT AN OFFICIALLY REGISTERED ID ] \
-            */
+#define ETH_P_BPQ                                                                                  \
+    0x08FF                     /* G8BPQ AX.25 Ethernet Packet  [ NOT AN OFFICIALLY REGISTERED ID ] \
+                                */
 #define ETH_P_IEEEPUP 0x0a00   /* Xerox IEEE802.3 PUP packet */
 #define ETH_P_IEEEPUPAT 0x0a01 /* Xerox IEEE802.3 PUP Addr Trans packet */
-#define ETH_P_BATMAN                                                           \
-    0x4305 /* B.A.T.M.A.N.-Advanced packet [ NOT AN OFFICIALLY REGISTERED ID ] \
-            */
+#define ETH_P_BATMAN                                                                               \
+    0x4305                  /* B.A.T.M.A.N.-Advanced packet [ NOT AN OFFICIALLY REGISTERED ID ]    \
+                             */
 #define ETH_P_DEC 0x6000    /* DEC Assigned proto           */
 #define ETH_P_DNA_DL 0x6001 /* DEC DNA Dump/Load            */
 #define ETH_P_DNA_RC 0x6002 /* DEC DNA Remote Console       */
@@ -185,8 +185,8 @@ enum {
 #define ETH_P_IPV6 0x86DD   /* IPv6 over bluebook           */
 #define ETH_P_PAUSE 0x8808  /* IEEE Pause frames. See 802.3 31B */
 #define ETH_P_SLOW 0x8809   /* Slow Protocol. See 802.3ad 43B */
-#define ETH_P_WCCP                                                             \
-    0x883E                    /* Web-cache coordination protocol               \
+#define ETH_P_WCCP                                                                                 \
+    0x883E                    /* Web-cache coordination protocol                                   \
                                * defined in draft-wilson-wrec-wccp-v2-00.txt */
 #define ETH_P_MPLS_UC 0x8847  /* MPLS Unicast traffic         */
 #define ETH_P_MPLS_MC 0x8848  /* MPLS Multicast traffic       */
@@ -194,9 +194,9 @@ enum {
 #define ETH_P_PPP_DISC 0x8863 /* PPPoE discovery messages     */
 #define ETH_P_PPP_SES 0x8864  /* PPPoE session messages       */
 #define ETH_P_LINK_CTL 0x886c /* HPNA, wlan link local tunnel */
-#define ETH_P_ATMFATE                                                          \
-    0x8884                   /* Frame-based ATM Transport                      \
-                              * over Ethernet                                  \
+#define ETH_P_ATMFATE                                                                              \
+    0x8884                   /* Frame-based ATM Transport                                          \
+                              * over Ethernet                                                      \
                               */
 #define ETH_P_PAE 0x888E     /* Port Access Entity (IEEE 802.1X) */
 #define ETH_P_AOE 0x88A2     /* ATA over Ethernet            */
@@ -213,26 +213,21 @@ enum {
 #define ETH_P_IBOE 0x8915    /* Infiniband over Ethernet     */
 #define ETH_P_TDLS 0x890D    /* TDLS */
 #define ETH_P_FIP 0x8914     /* FCoE Initialization Protocol */
-#define ETH_P_80221                                                            \
-    0x8917               /* IEEE 802.21 Media Independent Handover Protocol    \
-                          */
-#define ETH_P_HSR 0x892F /* IEC 62439-3 HSRv1    */
-#define ETH_P_NSH 0x894F /* Network Service Header */
+#define ETH_P_80221                                                                                \
+    0x8917                    /* IEEE 802.21 Media Independent Handover Protocol                   \
+                               */
+#define ETH_P_HSR 0x892F      /* IEC 62439-3 HSRv1    */
+#define ETH_P_NSH 0x894F      /* Network Service Header */
 #define ETH_P_LOOPBACK 0x9000 /* Ethernet loopback packet, per IEEE 802.3 */
-#define ETH_P_QINQ1                                                            \
-    0x9100 /* deprecated QinQ VLAN [ NOT AN OFFICIALLY REGISTERED ID ] */
-#define ETH_P_QINQ2                                                            \
-    0x9200 /* deprecated QinQ VLAN [ NOT AN OFFICIALLY REGISTERED ID ] */
-#define ETH_P_QINQ3                                                            \
-    0x9300 /* deprecated QinQ VLAN [ NOT AN OFFICIALLY REGISTERED ID ] */
-#define ETH_P_EDSA                                                             \
-    0xDADA               /* Ethertype DSA [ NOT AN OFFICIALLY REGISTERED ID ] */
-#define ETH_P_IFE 0xED3E /* ForCES inter-FE LFB type */
-#define ETH_P_AF_IUCV                                                          \
-    0xFBFB /* IBM af_iucv [ NOT AN OFFICIALLY REGISTERED ID ] */
+#define ETH_P_QINQ1 0x9100    /* deprecated QinQ VLAN [ NOT AN OFFICIALLY REGISTERED ID ] */
+#define ETH_P_QINQ2 0x9200    /* deprecated QinQ VLAN [ NOT AN OFFICIALLY REGISTERED ID ] */
+#define ETH_P_QINQ3 0x9300    /* deprecated QinQ VLAN [ NOT AN OFFICIALLY REGISTERED ID ] */
+#define ETH_P_EDSA 0xDADA     /* Ethertype DSA [ NOT AN OFFICIALLY REGISTERED ID ] */
+#define ETH_P_IFE 0xED3E      /* ForCES inter-FE LFB type */
+#define ETH_P_AF_IUCV 0xFBFB  /* IBM af_iucv [ NOT AN OFFICIALLY REGISTERED ID ] */
 
-#define ETH_P_802_3_MIN                                                        \
-    0x0600 /* If the value in the ethernet type is less than this value        \
+#define ETH_P_802_3_MIN                                                                            \
+    0x0600 /* If the value in the ethernet type is less than this value                            \
             * then the frame is Ethernet II. Else it is 802.3 */
 
 #define TC_ACT_UNSPEC (-1)
@@ -320,11 +315,11 @@ struct tcphdr {
     __be32 seq;
     __be32 ack_seq;
 #if defined(__LITTLE_ENDIAN_BITFIELD)
-    __u16 res1 : 4, doff : 4, fin : 1, syn : 1, rst : 1, psh : 1, ack : 1,
-        urg : 1, ece : 1, cwr : 1;
+    __u16 res1 : 4, doff : 4, fin : 1, syn : 1, rst : 1, psh : 1, ack : 1, urg : 1, ece : 1,
+        cwr : 1;
 #elif defined(__BIG_ENDIAN_BITFIELD)
-    __u16 doff : 4, res1 : 4, cwr : 1, ece : 1, urg : 1, ack : 1, psh : 1,
-        rst : 1, syn : 1, fin : 1;
+    __u16 doff : 4, res1 : 4, cwr : 1, ece : 1, urg : 1, ack : 1, psh : 1, rst : 1, syn : 1,
+        fin : 1;
 #else
 #error "Adjust your <asm/byteorder.h> defines"
 #endif

--- a/GPL/HostIsolation/TcFilter/TcFilter.bpf.c
+++ b/GPL/HostIsolation/TcFilter/TcFilter.bpf.c
@@ -81,18 +81,15 @@ __attribute__((always_inline)) static int allow_destination_IP(struct iphdr *ip)
     }
 }
 
-__attribute__((always_inline)) static int
-allow_tcp_pkt_egress(struct tcphdr *tcp, struct iphdr *ip)
+__attribute__((always_inline)) static int allow_tcp_pkt_egress(struct tcphdr *tcp, struct iphdr *ip)
 {
     /* TCP packets are currently only filtered based on destination IP */
     return allow_destination_IP(ip);
 }
 
-__attribute__((always_inline)) static int
-allow_udp_pkt_egress(struct udphdr *udp)
+__attribute__((always_inline)) static int allow_udp_pkt_egress(struct udphdr *udp)
 {
-    if ((DNS_PORT == bpf_ntohs(udp->source)) ||
-        (DNS_PORT == bpf_ntohs(udp->dest))) {
+    if ((DNS_PORT == bpf_ntohs(udp->source)) || (DNS_PORT == bpf_ntohs(udp->dest))) {
         /* allow DNS port (both client and server) */
         return 1;
 #if 0

--- a/GPL/HostIsolation/TcFilter/TcFilter.bpf.c
+++ b/GPL/HostIsolation/TcFilter/TcFilter.bpf.c
@@ -19,29 +19,26 @@
  */
 
 #include "Kerneldefs.h"
-#include "bpf_helpers.h"
-#include "bpf_endian.h"
 #include "TcFilterdefs.h"
+#include "bpf_endian.h"
+#include "bpf_helpers.h"
 
 #ifndef __section
-# define __section(NAME)                  \
-   __attribute__((section(NAME), used))
+#define __section(NAME) __attribute__((section(NAME), used))
 #endif
-
 
 // you took NULL for granted didn't you :)
 #define NULL 0
 
-#define BPF_F_NO_PREALLOC	(1U << 0)
+#define BPF_F_NO_PREALLOC (1U << 0)
 
 /* Key of an a BPF_MAP_TYPE_LPM_TRIE entry */
 struct bpf_lpm_trie_key {
-	__u32	prefixlen;	/* up to 32 for AF_INET, 128 for AF_INET6 */
-	__u32	data;	/* Arbitrary size */
+    __u32 prefixlen; /* up to 32 for AF_INET, 128 for AF_INET6 */
+    __u32 data;      /* Arbitrary size */
 };
 
-struct
-{
+struct {
     __uint(type, BPF_MAP_TYPE_HASH);
     __uint(key_size, sizeof(int));
     __uint(value_size, sizeof(int));
@@ -49,8 +46,7 @@ struct
     __uint(pinning, LIBBPF_PIN_BY_NAME);
 } allowed_IPs __section(".maps");
 
-struct
-{
+struct {
     __uint(type, BPF_MAP_TYPE_LPM_TRIE);
     __uint(key_size, 8);
     __uint(value_size, sizeof(int));
@@ -59,57 +55,44 @@ struct
     __uint(map_flags, BPF_F_NO_PREALLOC);
 } allowed_subnets __section(".maps");
 
-__attribute__((always_inline))
-static int
-allow_destination_IP(
-    struct iphdr *ip)
+__attribute__((always_inline)) static int allow_destination_IP(struct iphdr *ip)
 {
-    __u32 *elem = NULL;
+    __u32 *elem                     = NULL;
     struct bpf_lpm_trie_key lpm_key = {
         .prefixlen = 32,
-        .data = ip->daddr,
+        .data      = ip->daddr,
     };
 
     /* Check allowed IPs map first */
     elem = bpf_map_lookup_elem(&allowed_IPs, &ip->daddr);
-    if (elem)
-    {
+    if (elem) {
         /* IP is allowed */
         return 1;
     }
 
     /* Now check allowed subnets */
     elem = bpf_map_lookup_elem(&allowed_subnets, &lpm_key);
-    if (!elem)
-    {
+    if (!elem) {
         /* destination IP not within any allowed subnets - reject */
         return 0;
-    }
-    else
-    {
+    } else {
         /* IP matches allowed subnet */
         return 1;
     }
 }
 
-__attribute__((always_inline))
-static int
-allow_tcp_pkt_egress(
-    struct tcphdr *tcp,
-    struct iphdr *ip)
+__attribute__((always_inline)) static int
+allow_tcp_pkt_egress(struct tcphdr *tcp, struct iphdr *ip)
 {
     /* TCP packets are currently only filtered based on destination IP */
     return allow_destination_IP(ip);
 }
 
-__attribute__((always_inline))
-static int
-allow_udp_pkt_egress(
-    struct udphdr *udp)
+__attribute__((always_inline)) static int
+allow_udp_pkt_egress(struct udphdr *udp)
 {
     if ((DNS_PORT == bpf_ntohs(udp->source)) ||
-        (DNS_PORT == bpf_ntohs(udp->dest)))
-    {
+        (DNS_PORT == bpf_ntohs(udp->dest))) {
         /* allow DNS port (both client and server) */
         return 1;
 #if 0
@@ -120,52 +103,44 @@ allow_udp_pkt_egress(
         __u16 *dns = udp + 1;
 #endif
 
-    }
-    else if
-        (((DHCP_SERVER_PORT == bpf_ntohs(udp->dest)) && (DHCP_CLIENT_PORT == bpf_ntohs(udp->source))) ||
-         ((DHCP_CLIENT_PORT == bpf_ntohs(udp->dest)) && (DHCP_SERVER_PORT == bpf_ntohs(udp->source))))
-    {
+    } else if (((DHCP_SERVER_PORT == bpf_ntohs(udp->dest)) &&
+                (DHCP_CLIENT_PORT == bpf_ntohs(udp->source))) ||
+               ((DHCP_CLIENT_PORT == bpf_ntohs(udp->dest)) &&
+                (DHCP_SERVER_PORT == bpf_ntohs(udp->source)))) {
         /* allow DHCP ports (both client and server) */
         return 1;
-    }
-    else
-    {
+    } else {
         /* drop packet */
         return 0;
     }
 }
 
-int
-classifier(
-    struct __sk_buff *skb)
+int classifier(struct __sk_buff *skb)
 {
     struct ethhdr *eth = NULL;
-    struct iphdr *ip = NULL;
-    void *data_end = (void *)(long)skb->data_end;
-    void *data = (void *)(long)skb->data;
-    __u32 eth_proto = 0;
-    int rv = DROP_PACKET;
+    struct iphdr *ip   = NULL;
+    void *data_end     = (void *)(long)skb->data_end;
+    void *data         = (void *)(long)skb->data;
+    __u32 eth_proto    = 0;
+    int rv             = DROP_PACKET;
 
-    if (data + sizeof(struct ethhdr) > data_end)
-    {
+    if (data + sizeof(struct ethhdr) > data_end) {
         /* packet too small */
         rv = DROP_PACKET;
         goto out;
     }
 
-    eth = data;
+    eth       = data;
     eth_proto = eth->h_proto;
 
     /* check L3 protocol */
-    if (eth_proto == bpf_htons(ETH_P_ARP))
-    {
+    if (eth_proto == bpf_htons(ETH_P_ARP)) {
         /* allow ARP */
         rv = ALLOW_PACKET;
         goto out;
     }
 
-    if (eth_proto != bpf_htons(ETH_P_IP))
-    {
+    if (eth_proto != bpf_htons(ETH_P_IP)) {
         /* drop protocols other than IPv4 and ARP */
         rv = DROP_PACKET;
         goto out;
@@ -173,28 +148,25 @@ classifier(
 
     ip = data + sizeof(struct ethhdr);
 
-    if (ip + 1 > data_end)
-    {
+    if (ip + 1 > data_end) {
         rv = DROP_PACKET;
         goto out;
     }
 
-    if (4 != ip->version)
-    {
+    if (4 != ip->version) {
         /* drop IPv6 */
         rv = DROP_PACKET;
         goto out;
     }
 
-    if (5 != ip->ihl)
-    {
-        /* drop packets with IP options (5 == 20 bytes == min IP header size ) */
+    if (5 != ip->ihl) {
+        /* drop packets with IP options (5 == 20 bytes == min IP header size )
+         */
         rv = DROP_PACKET;
         goto out;
     }
 
-    if (ip->frag_off & PCKT_FRAGMENTED)
-    {
+    if (ip->frag_off & PCKT_FRAGMENTED) {
         /* drop fragmented packets */
         rv = DROP_PACKET;
         goto out;
@@ -202,64 +174,46 @@ classifier(
 
     __u8 protocol = ip->protocol;
 
-    if (protocol == IPPROTO_UDP)
-    {
+    if (protocol == IPPROTO_UDP) {
         /* handle UDP */
         struct udphdr *udp = ip + 1;
-        if (udp + 1 > data_end)
-        {
+        if (udp + 1 > data_end) {
             rv = DROP_PACKET;
             goto out;
         }
 
-        if (!allow_udp_pkt_egress(udp))
-        {
+        if (!allow_udp_pkt_egress(udp)) {
             rv = DROP_PACKET;
             goto out;
-        }
-        else
-        {
+        } else {
             rv = ALLOW_PACKET;
             goto out;
         }
-    }
-    else if (protocol == IPPROTO_TCP)
-    {
+    } else if (protocol == IPPROTO_TCP) {
         /* handle TCP */
         struct tcphdr *tcp = ip + 1;
-        if (tcp + 1 > data_end)
-        {
+        if (tcp + 1 > data_end) {
             rv = DROP_PACKET;
             goto out;
         }
 
-        if (!allow_tcp_pkt_egress(tcp, ip))
-        {
+        if (!allow_tcp_pkt_egress(tcp, ip)) {
             rv = DROP_PACKET;
             goto out;
-        }
-        else
-        {
+        } else {
             rv = ALLOW_PACKET;
             goto out;
         }
-    }
-    else if (protocol == IPPROTO_ICMP)
-    {
+    } else if (protocol == IPPROTO_ICMP) {
         /* check IP exceptionlist for ICMP */
-        if (!allow_destination_IP(ip))
-        {
+        if (!allow_destination_IP(ip)) {
             rv = DROP_PACKET;
             goto out;
-        }
-        else
-        {
+        } else {
             rv = ALLOW_PACKET;
             goto out;
         }
-    }
-    else
-    {
+    } else {
         /* drop other protos */
         rv = DROP_PACKET;
         goto out;
@@ -270,4 +224,3 @@ out:
 }
 
 char __license[] __section("license") = "GPL";
-

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -216,6 +216,23 @@ def getTestClosures()
     return test_closures
 }
 
+def validateFormatting()
+{
+    def path  = "/opt/endpoint-dev/dev/toolchain/bin"
+
+    withEnv(["PATH=${path}:$PATH"])
+    {
+        try
+        {
+            sh "find GPL/ non-GPL/ -name '*.[c, h]' | xargs clang-format -Werror --dry-run"
+        }
+        catch(Exception e)
+        {
+            error("Error running clang-format");
+        }
+    }
+}
+
 def buildAndStash(arch)
 {
     def cpath = "/opt/endpoint-dev/dev/sysroot/x86_64-linux-gnu/usr/include"
@@ -302,6 +319,17 @@ pipeline {
 
     stages
     {
+        stage('Formatting')
+        {
+            steps
+            {
+                script
+                {
+                    validateFormatting()
+                }
+            }
+        }
+
         stage('Build')
         {
             steps

--- a/non-GPL/Common/Common.c
+++ b/non-GPL/Common/Common.c
@@ -1,63 +1,53 @@
 // SPDX-License-Identifier: LicenseRef-Elastic-License-2.0
 
 /*
- * Copyright 2021 Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the Elastic License 2.0;
- * you may not use this file except in compliance with the Elastic License 2.0.
+ * Copyright 2021 Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under
+ * one or more contributor license agreements. Licensed under the Elastic
+ * License 2.0; you may not use this file except in compliance with the Elastic
+ * License 2.0.
  */
-
 
 //
 // eBPF common
 //
 
+#include "Common.h"
+
 #include <argp.h>
 #include <unistd.h>
 
-#include "Common.h"
-
-struct ebpf_maps_info ebpf_maps[EBPF_MAP_NUM] =
-{
-{
-    .type    = BPF_MAP_TYPE_HASH,
-    .name        = EBPF_ALLOWED_IPS_MAP_NAME,
-    .key_size    = sizeof(int),
-    .value_size  = sizeof(int),
-    .max_entries = 512,
-    .map_flags       = 0
-},
-{
-    .type    = BPF_MAP_TYPE_LPM_TRIE,
-    .name        = EBPF_ALLOWED_SUBNETS_MAP_NAME,
-    .key_size    = 8,
-    .value_size  = sizeof(int),
-    .max_entries = 256,
-    .map_flags       = BPF_F_NO_PREALLOC
-},
-{
-    .type    = BPF_MAP_TYPE_HASH,
-    .name        = EBPF_ALLOWED_PIDS_MAP_NAME,
-    .key_size    = sizeof(int),
-    .value_size  = sizeof(int),
-    .max_entries = 128,
-    .map_flags       = 0
-},
+struct ebpf_maps_info ebpf_maps[EBPF_MAP_NUM] = {
+    {.type        = BPF_MAP_TYPE_HASH,
+     .name        = EBPF_ALLOWED_IPS_MAP_NAME,
+     .key_size    = sizeof(int),
+     .value_size  = sizeof(int),
+     .max_entries = 512,
+     .map_flags   = 0},
+    {.type        = BPF_MAP_TYPE_LPM_TRIE,
+     .name        = EBPF_ALLOWED_SUBNETS_MAP_NAME,
+     .key_size    = 8,
+     .value_size  = sizeof(int),
+     .max_entries = 256,
+     .map_flags   = BPF_F_NO_PREALLOC},
+    {.type        = BPF_MAP_TYPE_HASH,
+     .name        = EBPF_ALLOWED_PIDS_MAP_NAME,
+     .key_size    = sizeof(int),
+     .value_size  = sizeof(int),
+     .max_entries = 128,
+     .map_flags   = 0},
 };
 
 // common log function
 static libbpf_print_fn_t g_log_func = libbpf_print_fn;
 
-int
-libbpf_print_fn(enum libbpf_print_level level,
-                const char *format,
-                va_list args)
+int libbpf_print_fn(enum libbpf_print_level level,
+                    const char *format,
+                    va_list args)
 {
     return vfprintf(stderr, format, args);
 }
 
-__attribute__((format(printf, 1, 2)))
-void
-ebpf_log(const char *format, ...)
+__attribute__((format(printf, 1, 2))) void ebpf_log(const char *format, ...)
 {
     va_list args;
 
@@ -69,15 +59,9 @@ ebpf_log(const char *format, ...)
     va_end(args);
 }
 
+libbpf_print_fn_t ebpf_default_log_func() { return libbpf_print_fn; }
 
-libbpf_print_fn_t
-ebpf_default_log_func()
-{
-    return libbpf_print_fn;
-}
-
-void
-ebpf_set_log_func(libbpf_print_fn_t fn)
+void ebpf_set_log_func(libbpf_print_fn_t fn)
 {
     // set log function for this module
     g_log_func = fn;

--- a/non-GPL/Common/Common.c
+++ b/non-GPL/Common/Common.c
@@ -57,7 +57,10 @@ __attribute__((format(printf, 1, 2))) void ebpf_log(const char *format, ...)
     va_end(args);
 }
 
-libbpf_print_fn_t ebpf_default_log_func() { return libbpf_print_fn; }
+libbpf_print_fn_t ebpf_default_log_func()
+{
+    return libbpf_print_fn;
+}
 
 void ebpf_set_log_func(libbpf_print_fn_t fn)
 {

--- a/non-GPL/Common/Common.c
+++ b/non-GPL/Common/Common.c
@@ -40,9 +40,7 @@ struct ebpf_maps_info ebpf_maps[EBPF_MAP_NUM] = {
 // common log function
 static libbpf_print_fn_t g_log_func = libbpf_print_fn;
 
-int libbpf_print_fn(enum libbpf_print_level level,
-                    const char *format,
-                    va_list args)
+int libbpf_print_fn(enum libbpf_print_level level, const char *format, va_list args)
 {
     return vfprintf(stderr, format, args);
 }

--- a/non-GPL/Common/Common.h
+++ b/non-GPL/Common/Common.h
@@ -18,8 +18,7 @@
 #define EBPF_ALLOWED_IPS_MAP_NAME "allowed_IPs"
 #define EBPF_ALLOWED_IPS_MAP_PATH "/sys/fs/bpf/elastic/endpoint/allowed_IPs"
 #define EBPF_ALLOWED_SUBNETS_MAP_NAME "allowed_subnets"
-#define EBPF_ALLOWED_SUBNETS_MAP_PATH                                          \
-    "/sys/fs/bpf/elastic/endpoint/allowed_subnets"
+#define EBPF_ALLOWED_SUBNETS_MAP_PATH "/sys/fs/bpf/elastic/endpoint/allowed_subnets"
 #define EBPF_ALLOWED_PIDS_MAP_NAME "allowed_pids"
 #define EBPF_ALLOWED_PIDS_MAP_PATH "/sys/fs/bpf/elastic/endpoint/allowed_pids"
 
@@ -50,9 +49,7 @@ extern struct ebpf_maps_info ebpf_maps[EBPF_MAP_NUM];
  * @param[in] args Arguments to format string
  * @return
  */
-int libbpf_print_fn(enum libbpf_print_level level,
-                    const char *format,
-                    va_list args);
+int libbpf_print_fn(enum libbpf_print_level level, const char *format, va_list args);
 
 /**
  * @brief Log function which is used by this eBPF library

--- a/non-GPL/Common/Common.h
+++ b/non-GPL/Common/Common.h
@@ -1,9 +1,10 @@
 // SPDX-License-Identifier: LicenseRef-Elastic-License-2.0
 
 /*
- * Copyright 2021 Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the Elastic License 2.0;
- * you may not use this file except in compliance with the Elastic License 2.0.
+ * Copyright 2021 Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under
+ * one or more contributor license agreements. Licensed under the Elastic
+ * License 2.0; you may not use this file except in compliance with the Elastic
+ * License 2.0.
  */
 
 #ifndef EBPF_COMMON_H
@@ -12,27 +13,26 @@
 #include <bpf/bpf.h>
 #include <bpf/libbpf.h>
 
-#define EBPF_MAP_PARENT_DIRECTORY       "/sys/fs/bpf/elastic"
-#define EBPF_MAP_DIRECTORY              "/sys/fs/bpf/elastic/endpoint"
-#define EBPF_ALLOWED_IPS_MAP_NAME       "allowed_IPs"
-#define EBPF_ALLOWED_IPS_MAP_PATH       "/sys/fs/bpf/elastic/endpoint/allowed_IPs"
-#define EBPF_ALLOWED_SUBNETS_MAP_NAME   "allowed_subnets"
-#define EBPF_ALLOWED_SUBNETS_MAP_PATH   "/sys/fs/bpf/elastic/endpoint/allowed_subnets"
-#define EBPF_ALLOWED_PIDS_MAP_NAME      "allowed_pids"
-#define EBPF_ALLOWED_PIDS_MAP_PATH      "/sys/fs/bpf/elastic/endpoint/allowed_pids"
+#define EBPF_MAP_PARENT_DIRECTORY "/sys/fs/bpf/elastic"
+#define EBPF_MAP_DIRECTORY "/sys/fs/bpf/elastic/endpoint"
+#define EBPF_ALLOWED_IPS_MAP_NAME "allowed_IPs"
+#define EBPF_ALLOWED_IPS_MAP_PATH "/sys/fs/bpf/elastic/endpoint/allowed_IPs"
+#define EBPF_ALLOWED_SUBNETS_MAP_NAME "allowed_subnets"
+#define EBPF_ALLOWED_SUBNETS_MAP_PATH                                          \
+    "/sys/fs/bpf/elastic/endpoint/allowed_subnets"
+#define EBPF_ALLOWED_PIDS_MAP_NAME "allowed_pids"
+#define EBPF_ALLOWED_PIDS_MAP_PATH "/sys/fs/bpf/elastic/endpoint/allowed_pids"
 
-struct ebpf_maps_info
-{
+struct ebpf_maps_info {
     enum bpf_map_type type;
-    const char        *name;
-    int               key_size;
-    int               value_size;
-    int               max_entries;
-    uint32_t          map_flags;
+    const char *name;
+    int key_size;
+    int value_size;
+    int max_entries;
+    uint32_t map_flags;
 };
 
-enum ebpf_hostisolation_map
-{
+enum ebpf_hostisolation_map {
     EBPF_MAP_ALLOWED_IPS = 0,
     EBPF_MAP_ALLOWED_SUBNETS,
     EBPF_MAP_ALLOWED_PIDS,
@@ -50,10 +50,9 @@ extern struct ebpf_maps_info ebpf_maps[EBPF_MAP_NUM];
  * @param[in] args Arguments to format string
  * @return
  */
-int
-libbpf_print_fn(enum libbpf_print_level level,
-                const char *format,
-                va_list args);
+int libbpf_print_fn(enum libbpf_print_level level,
+                    const char *format,
+                    va_list args);
 
 /**
  * @brief Log function which is used by this eBPF library
@@ -61,20 +60,17 @@ libbpf_print_fn(enum libbpf_print_level level,
  * @param[in] format Format string
  * @param[in] args Arguments to format string
  */
-void
-ebpf_log(const char *format, ...);
+void ebpf_log(const char *format, ...);
 
 /**
  * @brief Returns the default log function used by the library
  * @return
  */
-libbpf_print_fn_t
-ebpf_default_log_func();
+libbpf_print_fn_t ebpf_default_log_func();
 
 /**
  * @brief Set a custom log function to be used by the eBPF library and libbpf
  * @param[in] fn Log function
  */
-void
-ebpf_set_log_func(libbpf_print_fn_t fn);
+void ebpf_set_log_func(libbpf_print_fn_t fn);
 #endif

--- a/non-GPL/EventsTrace/EventsTrace.c
+++ b/non-GPL/EventsTrace/EventsTrace.c
@@ -23,8 +23,7 @@ static void sig_int(int signo)
     fprintf(stdout, "Received SIGINT, Exiting...\n");
 }
 
-static void ebpf_file_event_path__tostring(struct ebpf_file_path path,
-                                           char *pathbuf)
+static void ebpf_file_event_path__tostring(struct ebpf_file_path path, char *pathbuf)
 {
     strcpy(pathbuf, "/");
     for (int i = 0; i < path.patharray_len; i++) {
@@ -44,15 +43,9 @@ static void out_object_start() { printf("{"); }
 
 static void out_object_end() { printf("}"); }
 
-static void out_event_type(const char *type)
-{
-    printf("\"event_type\":\"%s\"", type);
-}
+static void out_event_type(const char *type) { printf("\"event_type\":\"%s\"", type); }
 
-static void out_int(const char *name, const int value)
-{
-    printf("\"%s\":%d", name, value);
-}
+static void out_int(const char *name, const int value) { printf("\"%s\":%d", name, value); }
 
 static void out_string(const char *name, const char *value)
 {
@@ -189,10 +182,9 @@ int main(int argc, char const *argv[])
     struct ebpf_event_ctx *ctx;
     uint64_t features = EBPF_KERNEL_FEATURE_BPF;
     uint64_t events   = EBPF_EVENT_FILE_DELETE;
-    err = ebpf_event_ctx__new(&ctx, event_ctx_callback, features, events);
+    err               = ebpf_event_ctx__new(&ctx, event_ctx_callback, features, events);
     if (err < 0) {
-        fprintf(stderr, "Could not create event context: %d %s\n", err,
-                strerror(-err));
+        fprintf(stderr, "Could not create event context: %d %s\n", err, strerror(-err));
         goto cleanup;
     }
 

--- a/non-GPL/EventsTrace/EventsTrace.c
+++ b/non-GPL/EventsTrace/EventsTrace.c
@@ -1,15 +1,16 @@
 // SPDX-License-Identifier: LicenseRef-Elastic-License-2.0
 
 /*
- * Copyright 2021 Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the Elastic License 2.0;
- * you may not use this file except in compliance with the Elastic License 2.0.
+ * Copyright 2021 Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under
+ * one or more contributor license agreements. Licensed under the Elastic
+ * License 2.0; you may not use this file except in compliance with the Elastic
+ * License 2.0.
  */
 
-#include <stdio.h>
 #include <errno.h>
-#include <string.h>
 #include <signal.h>
+#include <stdio.h>
+#include <string.h>
 
 #define __aligned_u64 __u64 __attribute__((aligned(8)))
 #include <LibEbpfEvents.h>
@@ -22,43 +23,30 @@ static void sig_int(int signo)
     fprintf(stdout, "Received SIGINT, Exiting...\n");
 }
 
-static void ebpf_file_event_path__tostring(struct ebpf_file_path path, char *pathbuf)
+static void ebpf_file_event_path__tostring(struct ebpf_file_path path,
+                                           char *pathbuf)
 {
     strcpy(pathbuf, "/");
-    for (int i = 0; i < path.patharray_len; i++)
-    {
+    for (int i = 0; i < path.patharray_len; i++) {
         strcat(pathbuf, path.path_array[i]);
 
-        if (i != path.patharray_len - 1)
-        {
+        if (i != path.patharray_len - 1) {
             strcat(pathbuf, "/");
         }
     }
 }
 
-static void out_comma()
-{
-    printf(",");
-}
+static void out_comma() { printf(","); }
+
+static void out_newline() { printf("\n"); }
+
+static void out_object_start() { printf("{"); }
+
+static void out_object_end() { printf("}"); }
 
 static void out_event_type(const char *type)
 {
     printf("\"event_type\":\"%s\"", type);
-}
-
-static void out_newline()
-{
-    printf("\n");
-}
-
-static void out_object_start()
-{
-    printf("{");
-}
-
-static void out_object_end()
-{
-    printf("}");
 }
 
 static void out_int(const char *name, const int value)
@@ -108,7 +96,7 @@ static void out_argv(const char *name, char *buf, size_t buf_size)
 
     for (int i = buf_size - 2; i >= 0; i--) {
         if (scratch_space[i] != ' ') {
-            scratch_space[i+1] = '\0';
+            scratch_space[i + 1] = '\0';
             break;
         }
     }
@@ -171,17 +159,17 @@ static void out_process_exec(struct ebpf_process_exec_event *evt)
 
 static int event_ctx_callback(struct ebpf_event_header *evt_hdr)
 {
-    switch(evt_hdr->type) {
+    switch (evt_hdr->type) {
     case EBPF_EVENT_FILE_DELETE:
-        out_file_delete((struct ebpf_file_delete_event *) evt_hdr);
+        out_file_delete((struct ebpf_file_delete_event *)evt_hdr);
         break;
 
     case EBPF_EVENT_PROCESS_FORK:
-        out_process_fork((struct ebpf_process_fork_event *) evt_hdr);
+        out_process_fork((struct ebpf_process_fork_event *)evt_hdr);
         break;
 
     case EBPF_EVENT_PROCESS_EXEC:
-        out_process_exec((struct ebpf_process_exec_event *) evt_hdr);
+        out_process_exec((struct ebpf_process_exec_event *)evt_hdr);
         break;
     }
 
@@ -190,38 +178,34 @@ static int event_ctx_callback(struct ebpf_event_header *evt_hdr)
 
 int main(int argc, char const *argv[])
 {
-    int err = 0;
+    int err                      = 0;
     struct FileEvents_bpf *probe = NULL;
 
-    if (signal(SIGINT, sig_int) == SIG_ERR)
-    {
+    if (signal(SIGINT, sig_int) == SIG_ERR) {
         fprintf(stderr, "Failed to register SIGINT handler\n");
         goto cleanup;
     }
 
     struct ebpf_event_ctx *ctx;
     uint64_t features = EBPF_KERNEL_FEATURE_BPF;
-    uint64_t events = EBPF_EVENT_FILE_DELETE;
+    uint64_t events   = EBPF_EVENT_FILE_DELETE;
     err = ebpf_event_ctx__new(&ctx, event_ctx_callback, features, events);
     if (err < 0) {
-        fprintf(stderr, "Could not create event context: %d %s\n",
-                err, strerror(-err));
+        fprintf(stderr, "Could not create event context: %d %s\n", err,
+                strerror(-err));
         goto cleanup;
     }
 
-    while (!exiting)
-    {
+    while (!exiting) {
         err = ebpf_event_ctx__next(ctx, 10);
-        if (err < 0)
-        {
+        if (err < 0) {
             fprintf(stderr, "Failed to poll event context\n");
             break;
         }
     }
 
 cleanup:
-    if (probe)
-    {
+    if (probe) {
         ebpf_event_ctx__destroy(ctx);
     }
     return err != 0;

--- a/non-GPL/EventsTrace/EventsTrace.c
+++ b/non-GPL/EventsTrace/EventsTrace.c
@@ -35,17 +35,35 @@ static void ebpf_file_event_path__tostring(struct ebpf_file_path path, char *pat
     }
 }
 
-static void out_comma() { printf(","); }
+static void out_comma()
+{
+    printf(",");
+}
 
-static void out_newline() { printf("\n"); }
+static void out_newline()
+{
+    printf("\n");
+}
 
-static void out_object_start() { printf("{"); }
+static void out_object_start()
+{
+    printf("{");
+}
 
-static void out_object_end() { printf("}"); }
+static void out_object_end()
+{
+    printf("}");
+}
 
-static void out_event_type(const char *type) { printf("\"event_type\":\"%s\"", type); }
+static void out_event_type(const char *type)
+{
+    printf("\"event_type\":\"%s\"", type);
+}
 
-static void out_int(const char *name, const int value) { printf("\"%s\":%d", name, value); }
+static void out_int(const char *name, const int value)
+{
+    printf("\"%s\":%d", name, value);
+}
 
 static void out_string(const char *name, const char *value)
 {

--- a/non-GPL/HostIsolation/KprobeConnectHook/KprobeConnectHookDemo.c
+++ b/non-GPL/HostIsolation/KprobeConnectHook/KprobeConnectHookDemo.c
@@ -42,8 +42,7 @@ static int try_load_ebpf_kprobe(const char *ebpf_file,
     printf("BPF FILE OPENED\n");
 
     // pin allowed_IPs map when program is loaded
-    rv = ebpf_map_set_pin_path(obj, EBPF_ALLOWED_IPS_MAP_NAME,
-                               EBPF_ALLOWED_IPS_MAP_PATH);
+    rv = ebpf_map_set_pin_path(obj, EBPF_ALLOWED_IPS_MAP_NAME, EBPF_ALLOWED_IPS_MAP_PATH);
     if (rv) {
         printf("failed to init " EBPF_ALLOWED_IPS_MAP_NAME " BPF map\n");
         rv = -1;
@@ -52,8 +51,7 @@ static int try_load_ebpf_kprobe(const char *ebpf_file,
     printf("BPF ALLOWED_IPS MAP LOADED\n");
 
     // pin allowed_pids map when program is loaded
-    rv = ebpf_map_set_pin_path(obj, EBPF_ALLOWED_PIDS_MAP_NAME,
-                               EBPF_ALLOWED_PIDS_MAP_PATH);
+    rv = ebpf_map_set_pin_path(obj, EBPF_ALLOWED_PIDS_MAP_NAME, EBPF_ALLOWED_PIDS_MAP_PATH);
     if (rv) {
         printf("failed to init " EBPF_ALLOWED_PIDS_MAP_NAME " BPF map\n");
         rv = -1;
@@ -63,8 +61,7 @@ static int try_load_ebpf_kprobe(const char *ebpf_file,
 
     // create elastic/endpoint dir in bpf fs
     if (mkdir(EBPF_MAP_PARENT_DIRECTORY, 0700) && errno != EEXIST) {
-        printf("failed to create " EBPF_MAP_PARENT_DIRECTORY " dir, err=%d\n",
-               errno);
+        printf("failed to create " EBPF_MAP_PARENT_DIRECTORY " dir, err=%d\n", errno);
         rv = -1;
         goto cleanup;
     }
@@ -74,8 +71,7 @@ static int try_load_ebpf_kprobe(const char *ebpf_file,
         goto cleanup;
     }
 
-    link =
-        ebpf_load_and_attach_kprobe(obj, "kprobe/tcp_v4_connect", load_method);
+    link = ebpf_load_and_attach_kprobe(obj, "kprobe/tcp_v4_connect", load_method);
     if (!link) {
         printf("failed to load and attach kprobe\n");
         rv = -1;
@@ -127,8 +123,7 @@ int main(int argc, char **argv)
     rv = -1;
     while (rv && load_method < EBPF_MAX_LOAD_METHODS) {
         printf("trying loading method %d\n", load_method);
-        rv = try_load_ebpf_kprobe("./KprobeConnectHook.bpf.o", load_method,
-                                  &obj, &link);
+        rv = try_load_ebpf_kprobe("./KprobeConnectHook.bpf.o", load_method, &obj, &link);
         load_method++;
     }
 

--- a/non-GPL/HostIsolation/KprobeConnectHook/KprobeConnectHookDemo.c
+++ b/non-GPL/HostIsolation/KprobeConnectHook/KprobeConnectHookDemo.c
@@ -1,42 +1,40 @@
 // SPDX-License-Identifier: LicenseRef-Elastic-License-2.0
 
 /*
- * Copyright 2021 Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the Elastic License 2.0;
- * you may not use this file except in compliance with the Elastic License 2.0.
+ * Copyright 2021 Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under
+ * one or more contributor license agreements. Licensed under the Elastic
+ * License 2.0; you may not use this file except in compliance with the Elastic
+ * License 2.0.
  */
-
 
 //
 // Host Isolation standalone demo
 // Loader for eBPF program #2 (attaches to tcp_v4_connect kprobe)
-// 
+//
+#include <Common.h>
 #include <argp.h>
-#include <unistd.h>
-#include <time.h>
+#include <arpa/inet.h>
 #include <bpf/bpf.h>
 #include <bpf/libbpf.h>
-#include <arpa/inet.h>
-#include <sys/stat.h>
 #include <sys/resource.h>
+#include <sys/stat.h>
+#include <time.h>
+#include <unistd.h>
 
-#include <Common.h>
 #include "KprobeLoader.h"
 
 // try to load and attach an eBPF kprobe program with a specified load_method
-static int
-try_load_ebpf_kprobe(const char *ebpf_file,
-                     enum ebpf_load_method load_method,
-                     struct bpf_object **bpf_obj,
-                     struct bpf_link **bpf_link)
+static int try_load_ebpf_kprobe(const char *ebpf_file,
+                                enum ebpf_load_method load_method,
+                                struct bpf_object **bpf_obj,
+                                struct bpf_link **bpf_link)
 {
     struct bpf_object *obj = NULL;
-    struct bpf_link *link = NULL;
-    int rv = 0;
+    struct bpf_link *link  = NULL;
+    int rv                 = 0;
 
     obj = ebpf_open_object_file(ebpf_file);
-    if (!obj)
-    {
+    if (!obj) {
         printf("failed to open BPF object\n");
         rv = -1;
         goto cleanup;
@@ -44,9 +42,9 @@ try_load_ebpf_kprobe(const char *ebpf_file,
     printf("BPF FILE OPENED\n");
 
     // pin allowed_IPs map when program is loaded
-    rv = ebpf_map_set_pin_path(obj, EBPF_ALLOWED_IPS_MAP_NAME, EBPF_ALLOWED_IPS_MAP_PATH);
-    if (rv)
-    {
+    rv = ebpf_map_set_pin_path(obj, EBPF_ALLOWED_IPS_MAP_NAME,
+                               EBPF_ALLOWED_IPS_MAP_PATH);
+    if (rv) {
         printf("failed to init " EBPF_ALLOWED_IPS_MAP_NAME " BPF map\n");
         rv = -1;
         goto cleanup;
@@ -54,9 +52,9 @@ try_load_ebpf_kprobe(const char *ebpf_file,
     printf("BPF ALLOWED_IPS MAP LOADED\n");
 
     // pin allowed_pids map when program is loaded
-    rv = ebpf_map_set_pin_path(obj, EBPF_ALLOWED_PIDS_MAP_NAME, EBPF_ALLOWED_PIDS_MAP_PATH);
-    if (rv)
-    {
+    rv = ebpf_map_set_pin_path(obj, EBPF_ALLOWED_PIDS_MAP_NAME,
+                               EBPF_ALLOWED_PIDS_MAP_PATH);
+    if (rv) {
         printf("failed to init " EBPF_ALLOWED_PIDS_MAP_NAME " BPF map\n");
         rv = -1;
         goto cleanup;
@@ -64,22 +62,21 @@ try_load_ebpf_kprobe(const char *ebpf_file,
     printf("BPF ALLOWED_PIDS MAP LOADED\n");
 
     // create elastic/endpoint dir in bpf fs
-    if (mkdir(EBPF_MAP_PARENT_DIRECTORY, 0700) && errno != EEXIST)
-    {
-        printf("failed to create " EBPF_MAP_PARENT_DIRECTORY " dir, err=%d\n", errno);
+    if (mkdir(EBPF_MAP_PARENT_DIRECTORY, 0700) && errno != EEXIST) {
+        printf("failed to create " EBPF_MAP_PARENT_DIRECTORY " dir, err=%d\n",
+               errno);
         rv = -1;
         goto cleanup;
     }
-    if (mkdir(EBPF_MAP_DIRECTORY, 0700) && errno != EEXIST)
-    {
+    if (mkdir(EBPF_MAP_DIRECTORY, 0700) && errno != EEXIST) {
         printf("failed to create " EBPF_MAP_DIRECTORY " dir, err=%d\n", errno);
         rv = -1;
         goto cleanup;
     }
 
-    link = ebpf_load_and_attach_kprobe(obj, "kprobe/tcp_v4_connect", load_method);
-    if (!link)
-    {
+    link =
+        ebpf_load_and_attach_kprobe(obj, "kprobe/tcp_v4_connect", load_method);
+    if (!link) {
         printf("failed to load and attach kprobe\n");
         rv = -1;
         goto cleanup;
@@ -89,46 +86,38 @@ try_load_ebpf_kprobe(const char *ebpf_file,
     rv = 0;
 
 cleanup:
-    if (rv)
-    {
+    if (rv) {
         ebpf_object_close(obj);
         ebpf_link_destroy(link);
-    }
-    else
-    {
-        *bpf_obj = obj;
+    } else {
+        *bpf_obj  = obj;
         *bpf_link = link;
     }
     return rv;
 }
 
-int
-main(int argc,
-     char **argv)
+int main(int argc, char **argv)
 {
-    struct bpf_object *obj = NULL;
-    struct bpf_link *link = NULL;
+    struct bpf_object *obj            = NULL;
+    struct bpf_link *link             = NULL;
     enum ebpf_load_method load_method = EBPF_METHOD_NO_OVERRIDE;
-    struct rlimit rl = {};
-    int rv = -1;
+    struct rlimit rl                  = {};
+    int rv                            = -1;
 
     ebpf_set_log_func(ebpf_default_log_func());
 
-    // increase locked memory rlimit to accommodate maps (which are treated as locked memory)
-    if (getrlimit(RLIMIT_MEMLOCK, &rl) == 0)
-    {
+    // increase locked memory rlimit to accommodate maps (which are treated as
+    // locked memory)
+    if (getrlimit(RLIMIT_MEMLOCK, &rl) == 0) {
         // set rlimit to 1MB
         rl.rlim_max = 1024 * 1024;
         rl.rlim_cur = rl.rlim_max;
-        if (setrlimit(RLIMIT_MEMLOCK, &rl) != 0)
-        {
+        if (setrlimit(RLIMIT_MEMLOCK, &rl) != 0) {
             printf("setting rlimit failed! please run with sudo\n");
             rv = -1;
             goto cleanup;
         }
-    }
-    else
-    {
+    } else {
         printf("setting rlimit failed! please run with sudo\n");
         rv = -1;
         goto cleanup;
@@ -136,15 +125,14 @@ main(int argc,
 
     // loading may fail on some older platforms - try all known methods
     rv = -1;
-    while (rv && load_method < EBPF_MAX_LOAD_METHODS)
-    {
+    while (rv && load_method < EBPF_MAX_LOAD_METHODS) {
         printf("trying loading method %d\n", load_method);
-        rv = try_load_ebpf_kprobe("./KprobeConnectHook.bpf.o", load_method, &obj, &link);
+        rv = try_load_ebpf_kprobe("./KprobeConnectHook.bpf.o", load_method,
+                                  &obj, &link);
         load_method++;
     }
 
-    if (rv)
-    {
+    if (rv) {
         goto cleanup;
     }
 

--- a/non-GPL/HostIsolation/KprobeConnectHook/KprobeLoader.c
+++ b/non-GPL/HostIsolation/KprobeConnectHook/KprobeLoader.c
@@ -1,27 +1,27 @@
 // SPDX-License-Identifier: LicenseRef-Elastic-License-2.0
 
 /*
- * Copyright 2021 Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the Elastic License 2.0;
- * you may not use this file except in compliance with the Elastic License 2.0.
+ * Copyright 2021 Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under
+ * one or more contributor license agreements. Licensed under the Elastic
+ * License 2.0; you may not use this file except in compliance with the Elastic
+ * License 2.0.
  */
-
 
 //
 // Host Isolation standalone demo
 // Loader for eBPF program #2 (attaches to tcp_v4_connect kprobe)
-// 
+//
 
-#include <stdio.h>
-#include <string.h>
-#include <bpf/bpf.h>
-#include <bpf/libbpf.h>
-#include <unistd.h>
+#include "KprobeLoader.h"
 
 #include <Common.h>
-#include "KprobeLoader.h"
+#include <bpf/bpf.h>
+#include <bpf/libbpf.h>
 #include <elf.h>
 #include <errno.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
 
 // requires glibc >= 2.16
 //#define GETAUXVAL_SUPPORTED
@@ -31,51 +31,46 @@
 #endif
 
 #if defined(__LP64__)
-#define ElfW(type) Elf64_ ## type
+#define ElfW(type) Elf64_##type
 #else
-#define ElfW(type) Elf32_ ## type
+#define ElfW(type) Elf32_##type
 #endif
 
-static unsigned int
-find_version_note(unsigned long base)
+static unsigned int find_version_note(unsigned long base)
 {
-    ElfW(Ehdr) *ehdr = NULL;
+    ElfW(Ehdr) *ehdr          = NULL;
     unsigned int version_code = 0;
-    int i = 0;
+    int i                     = 0;
 
-    if (!base)
-    {
+    if (!base) {
         ebpf_log("find_version_note error: NULL parameter\n");
         goto out;
     }
 
     ehdr = (ElfW(Ehdr) *)base;
 
-    for (i = 0; i < ehdr->e_shnum; i++)
-    {
-        ElfW(Shdr) *shdr = (ElfW(Shdr) *)(
-            base + ehdr->e_shoff + (i * ehdr->e_shentsize)
-        );
+    for (i = 0; i < ehdr->e_shnum; i++) {
+        ElfW(Shdr) *shdr =
+            (ElfW(Shdr) *)(base + ehdr->e_shoff + (i * ehdr->e_shentsize));
 
-        if (shdr->sh_type == SHT_NOTE)
-        {
+        if (shdr->sh_type == SHT_NOTE) {
             const char *ptr = (const char *)(base + shdr->sh_offset);
             const char *end = ptr + shdr->sh_size;
 
-            while (ptr < end)
-            {
+            while (ptr < end) {
                 ElfW(Nhdr) *nhdr = (ElfW(Nhdr) *)ptr;
                 ptr += sizeof(*nhdr);
 
                 const char *name = ptr;
-                ptr += (nhdr->n_namesz + sizeof(ElfW(Word)) - 1) & -sizeof(ElfW(Word));
+                ptr += (nhdr->n_namesz + sizeof(ElfW(Word)) - 1) &
+                       -sizeof(ElfW(Word));
 
                 const char *desc = ptr;
-                ptr += (nhdr->n_descsz + sizeof(ElfW(Word)) - 1) & -sizeof(ElfW(Word));
+                ptr += (nhdr->n_descsz + sizeof(ElfW(Word)) - 1) &
+                       -sizeof(ElfW(Word));
 
                 if ((nhdr->n_namesz > 5 && !memcmp(name, "Linux", 5)) &&
-                    nhdr->n_descsz == 4 && !nhdr->n_type)
-                {
+                    nhdr->n_descsz == 4 && !nhdr->n_type) {
                     version_code = *(uint32_t *)desc;
                     goto out;
                 }
@@ -87,8 +82,7 @@ out:
     return version_code;
 }
 
-static unsigned long
-get_auxiliary_vector_base(int at_key)
+static unsigned long get_auxiliary_vector_base(int at_key)
 {
     unsigned long base = 0;
 
@@ -96,110 +90,98 @@ get_auxiliary_vector_base(int at_key)
     base = getauxval(at_key);
     return base;
 #else
-	FILE *f = NULL;
+    FILE *f = NULL;
     int err = 0;
 
-	f = fopen("/proc/self/auxv", "r");
-	if (!f) {
-		err = -errno;
-		ebpf_log("failed to open /proc/self/auxv: %d\n", err);
-		return 0;
-	}
+    f = fopen("/proc/self/auxv", "r");
+    if (!f) {
+        err = -errno;
+        ebpf_log("failed to open /proc/self/auxv: %d\n", err);
+        return 0;
+    }
 
-	while (true) {
-        unsigned long key = 0;
+    while (true) {
+        unsigned long key   = 0;
         unsigned long value = 0;
-        int ret = -1;
-		ret = fread(&key, sizeof(key), 1, f);
-		if (ret != 1)
-			break;
-		ret = fread(&value, sizeof(value), 1, f);
-		if (ret != 1)
-			break;
-		if (key == 0 && value == 0)
-			break;
-        if (key == at_key)
-        {
+        int ret             = -1;
+        ret                 = fread(&key, sizeof(key), 1, f);
+        if (ret != 1)
+            break;
+        ret = fread(&value, sizeof(value), 1, f);
+        if (ret != 1)
+            break;
+        if (key == 0 && value == 0)
+            break;
+        if (key == at_key) {
             base = value;
             return base;
         }
-	}
+    }
     return base;
 #endif
 }
 
-static unsigned int
-get_kernel_version(enum ebpf_load_method method)
+static unsigned int get_kernel_version(enum ebpf_load_method method)
 {
     unsigned int code = 0;
-    int rv = 0;
-    FILE *f = NULL;
+    int rv            = 0;
+    FILE *f           = NULL;
 
-    switch (method)
-    {
-        case EBPF_METHOD_NO_OVERRIDE:
-        {
-            // default method - do not override kernel version
+    switch (method) {
+    case EBPF_METHOD_NO_OVERRIDE: {
+        // default method - do not override kernel version
+        code = 0;
+        goto out;
+    }
+    case EBPF_METHOD_VDSO: {
+        // Fetch LINUX_VERSION_CODE from the vDSO .note section.
+        // This always matches the running kernel, but is not supported on
+        // arm32.
+        unsigned long base = get_auxiliary_vector_base(AT_SYSINFO_EHDR);
+        // Check ELF magic value
+        if (base && !memcmp((void *)base, ELFMAG, 4)) {
+            code = find_version_note(base);
+        }
+        goto out;
+    }
+    case EBPF_METHOD_VERSION_H: {
+        // check if version.h exists
+        f = fopen("/usr/include/linux/version.h", "r");
+        if (!f) {
             code = 0;
             goto out;
         }
-        case EBPF_METHOD_VDSO:
-        {
-            // Fetch LINUX_VERSION_CODE from the vDSO .note section.
-            // This always matches the running kernel, but is not supported on arm32.
-            unsigned long base = get_auxiliary_vector_base(AT_SYSINFO_EHDR);
-            // Check ELF magic value
-            if (base && !memcmp((void *)base, ELFMAG, 4))
-            {
-                code = find_version_note(base);
-            }
-            goto out;
-        }
-        case EBPF_METHOD_VERSION_H:
-        {
-            // check if version.h exists
-            f = fopen("/usr/include/linux/version.h", "r");
-            if (!f)
-            {
-                code = 0;
-                goto out;
-            }
-            rv = fscanf(f, "#define LINUX_VERSION_CODE %d", &code);
-            if (rv != 1)
-            {
-                code = 0;
-                fclose(f);
-                goto out;
-            }
+        rv = fscanf(f, "#define LINUX_VERSION_CODE %d", &code);
+        if (rv != 1) {
+            code = 0;
             fclose(f);
             goto out;
         }
-        default:
-        {
-            code = 0;
-            goto out;
-        }
+        fclose(f);
+        goto out;
+    }
+    default: {
+        code = 0;
+        goto out;
+    }
     }
 
 out:
     return code;
 }
 
-struct bpf_object *
-ebpf_open_object_file(const char *file_path)
+struct bpf_object *ebpf_open_object_file(const char *file_path)
 {
     struct bpf_object *obj = NULL;
 
-    if (!file_path)
-    {
+    if (!file_path) {
         ebpf_log("error: file path is NULL\n");
         obj = NULL;
         goto cleanup;
     }
 
     obj = bpf_object__open_file(file_path, NULL);
-    if (!obj || libbpf_get_error(obj))
-    {
+    if (!obj || libbpf_get_error(obj)) {
         ebpf_log("failed to open BPF object\n");
         ebpf_object_close(obj);
         obj = NULL;
@@ -210,32 +192,28 @@ cleanup:
     return obj;
 }
 
-int
-ebpf_map_set_pin_path(struct bpf_object *obj,
-                      const char *map_name,
-                      const char *map_path)
+int ebpf_map_set_pin_path(struct bpf_object *obj,
+                          const char *map_name,
+                          const char *map_path)
 {
     struct bpf_map *map = NULL;
-    int rv = 0;
+    int rv              = 0;
 
-    if (!obj || !map_name || !map_path)
-    {
+    if (!obj || !map_name || !map_path) {
         ebpf_log("ebp_map_set_pin_path error: NULL parameter\n");
         rv = -1;
         goto cleanup;
     }
 
     map = bpf_object__find_map_by_name(obj, map_name);
-    if (!map || libbpf_get_error(map))
-    {
+    if (!map || libbpf_get_error(map)) {
         ebpf_log("failed to load %s BPF map\n", map_name);
         rv = -1;
         goto cleanup;
     }
 
     rv = bpf_map__set_pin_path(map, map_path);
-    if (rv)
-    {
+    if (rv) {
         ebpf_log("failed to set pin path for %s map\n", map_name);
         rv = -1;
         goto cleanup;
@@ -245,48 +223,44 @@ cleanup:
     return rv;
 }
 
-struct bpf_link *
-ebpf_load_and_attach_kprobe(struct bpf_object *obj,
-                            const char *program_sec_name,
-                            enum ebpf_load_method load_method)
+struct bpf_link *ebpf_load_and_attach_kprobe(struct bpf_object *obj,
+                                             const char *program_sec_name,
+                                             enum ebpf_load_method load_method)
 {
-    struct bpf_program *prog = NULL;
-    struct bpf_link *link = NULL;
-    int prog_fd = -1;
+    struct bpf_program *prog    = NULL;
+    struct bpf_link *link       = NULL;
+    int prog_fd                 = -1;
     unsigned int kernel_version = 0;
 
     // Load may fail if an incorrect kernel version number was passed to the
-    // bpf() syscall (old Linux kernels verify that, while newer kernels ignore it).
-    // Try one of the methods of getting the kernel version, set it in libbpf and load
+    // bpf() syscall (old Linux kernels verify that, while newer kernels ignore
+    // it). Try one of the methods of getting the kernel version, set it in
+    // libbpf and load
     kernel_version = get_kernel_version(load_method);
-    if (kernel_version != 0)
-    {
-        ebpf_log("got kernel_version=%d according to method=%d\n", kernel_version, load_method);
-        if (bpf_object__set_kversion(obj, kernel_version) != 0)
-        {
+    if (kernel_version != 0) {
+        ebpf_log("got kernel_version=%d according to method=%d\n",
+                 kernel_version, load_method);
+        if (bpf_object__set_kversion(obj, kernel_version) != 0) {
             ebpf_log("failed to set kversion\n");
         }
     }
 
     prog_fd = bpf_object__load(obj);
-    if (prog_fd < 0)
-    {
+    if (prog_fd < 0) {
         ebpf_log("failed to load BPF program\n");
         link = NULL;
         goto cleanup;
     }
 
     prog = bpf_object__find_program_by_title(obj, program_sec_name);
-    if (!prog || libbpf_get_error(prog))
-    {
+    if (!prog || libbpf_get_error(prog)) {
         ebpf_log("failed to find BPF program by name\n");
         link = NULL;
         goto cleanup;
     }
 
     link = bpf_program__attach(prog);
-    if (!link || libbpf_get_error(link))
-    {
+    if (!link || libbpf_get_error(link)) {
         ebpf_log("failed to attach BPF program\n");
         ebpf_link_destroy(link);
         link = NULL;
@@ -297,20 +271,16 @@ cleanup:
     return link;
 }
 
-void
-ebpf_link_destroy(struct bpf_link *link)
+void ebpf_link_destroy(struct bpf_link *link)
 {
-    if (link)
-    {
+    if (link) {
         bpf_link__destroy(link);
     }
 }
 
-void
-ebpf_object_close(struct bpf_object *obj)
+void ebpf_object_close(struct bpf_object *obj)
 {
-    if (obj)
-    {
+    if (obj) {
         bpf_object__close(obj);
     }
 }

--- a/non-GPL/HostIsolation/KprobeConnectHook/KprobeLoader.c
+++ b/non-GPL/HostIsolation/KprobeConnectHook/KprobeLoader.c
@@ -50,8 +50,7 @@ static unsigned int find_version_note(unsigned long base)
     ehdr = (ElfW(Ehdr) *)base;
 
     for (i = 0; i < ehdr->e_shnum; i++) {
-        ElfW(Shdr) *shdr =
-            (ElfW(Shdr) *)(base + ehdr->e_shoff + (i * ehdr->e_shentsize));
+        ElfW(Shdr) *shdr = (ElfW(Shdr) *)(base + ehdr->e_shoff + (i * ehdr->e_shentsize));
 
         if (shdr->sh_type == SHT_NOTE) {
             const char *ptr = (const char *)(base + shdr->sh_offset);
@@ -62,15 +61,13 @@ static unsigned int find_version_note(unsigned long base)
                 ptr += sizeof(*nhdr);
 
                 const char *name = ptr;
-                ptr += (nhdr->n_namesz + sizeof(ElfW(Word)) - 1) &
-                       -sizeof(ElfW(Word));
+                ptr += (nhdr->n_namesz + sizeof(ElfW(Word)) - 1) & -sizeof(ElfW(Word));
 
                 const char *desc = ptr;
-                ptr += (nhdr->n_descsz + sizeof(ElfW(Word)) - 1) &
-                       -sizeof(ElfW(Word));
+                ptr += (nhdr->n_descsz + sizeof(ElfW(Word)) - 1) & -sizeof(ElfW(Word));
 
-                if ((nhdr->n_namesz > 5 && !memcmp(name, "Linux", 5)) &&
-                    nhdr->n_descsz == 4 && !nhdr->n_type) {
+                if ((nhdr->n_namesz > 5 && !memcmp(name, "Linux", 5)) && nhdr->n_descsz == 4 &&
+                    !nhdr->n_type) {
                     version_code = *(uint32_t *)desc;
                     goto out;
                 }
@@ -192,9 +189,7 @@ cleanup:
     return obj;
 }
 
-int ebpf_map_set_pin_path(struct bpf_object *obj,
-                          const char *map_name,
-                          const char *map_path)
+int ebpf_map_set_pin_path(struct bpf_object *obj, const char *map_name, const char *map_path)
 {
     struct bpf_map *map = NULL;
     int rv              = 0;
@@ -238,8 +233,7 @@ struct bpf_link *ebpf_load_and_attach_kprobe(struct bpf_object *obj,
     // libbpf and load
     kernel_version = get_kernel_version(load_method);
     if (kernel_version != 0) {
-        ebpf_log("got kernel_version=%d according to method=%d\n",
-                 kernel_version, load_method);
+        ebpf_log("got kernel_version=%d according to method=%d\n", kernel_version, load_method);
         if (bpf_object__set_kversion(obj, kernel_version) != 0) {
             ebpf_log("failed to set kversion\n");
         }

--- a/non-GPL/HostIsolation/KprobeConnectHook/KprobeLoader.h
+++ b/non-GPL/HostIsolation/KprobeConnectHook/KprobeLoader.h
@@ -35,9 +35,7 @@ struct bpf_object *ebpf_open_object_file(const char *file_path);
  * @param[in] map_path Path to the eBPF map in the bpf filesystem
  * @return Error value (0 for success)
  */
-int ebpf_map_set_pin_path(struct bpf_object *obj,
-                          const char *map_name,
-                          const char *map_path);
+int ebpf_map_set_pin_path(struct bpf_object *obj, const char *map_name, const char *map_path);
 /**
  * @brief Load and attach eBPF program to a kprobe
  *

--- a/non-GPL/HostIsolation/KprobeConnectHook/KprobeLoader.h
+++ b/non-GPL/HostIsolation/KprobeConnectHook/KprobeLoader.h
@@ -1,9 +1,10 @@
 // SPDX-License-Identifier: LicenseRef-Elastic-License-2.0
 
 /*
- * Copyright 2021 Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the Elastic License 2.0;
- * you may not use this file except in compliance with the Elastic License 2.0.
+ * Copyright 2021 Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under
+ * one or more contributor license agreements. Licensed under the Elastic
+ * License 2.0; you may not use this file except in compliance with the Elastic
+ * License 2.0.
  */
 
 #ifndef EBPF_KPROBELOADER_H
@@ -11,8 +12,7 @@
 
 #include <Common.h>
 
-enum ebpf_load_method
-{
+enum ebpf_load_method {
     EBPF_METHOD_NO_OVERRIDE = 0,
     EBPF_METHOD_VDSO,
     EBPF_METHOD_VERSION_H,
@@ -25,8 +25,7 @@ enum ebpf_load_method
  * @param[in] file_path Path to the eBPF object file
  * @returns eBPF object handle to be passed to other functions
  */
-struct bpf_object *
-ebpf_open_object_file(const char *file_path);
+struct bpf_object *ebpf_open_object_file(const char *file_path);
 
 /**
  * @brief Pin eBPF map by name and path
@@ -36,10 +35,9 @@ ebpf_open_object_file(const char *file_path);
  * @param[in] map_path Path to the eBPF map in the bpf filesystem
  * @return Error value (0 for success)
  */
-int
-ebpf_map_set_pin_path(struct bpf_object *obj,
-                      const char *map_name,
-                      const char *map_path);
+int ebpf_map_set_pin_path(struct bpf_object *obj,
+                          const char *map_name,
+                          const char *map_path);
 /**
  * @brief Load and attach eBPF program to a kprobe
  *
@@ -47,24 +45,21 @@ ebpf_map_set_pin_path(struct bpf_object *obj,
  * @param[in] program_sec_name eBPF program name (section name in ELF)
  * @returns eBPF link handle to be passed to other functions
  */
-struct bpf_link *
-ebpf_load_and_attach_kprobe(struct bpf_object *obj,
-                            const char *program_sec_name,
-                            enum ebpf_load_method load_method);
+struct bpf_link *ebpf_load_and_attach_kprobe(struct bpf_object *obj,
+                                             const char *program_sec_name,
+                                             enum ebpf_load_method load_method);
 
 /**
  * @brief Destroy link and cleanup resources
  *
  * @param[in] link eBPF link handle
  */
-void
-ebpf_link_destroy(struct bpf_link *link);
+void ebpf_link_destroy(struct bpf_link *link);
 
 /**
  * @brief Close eBPF object and cleanup resources
  *
  * @param[in] obj eBPF object handle
  */
-void
-ebpf_object_close(struct bpf_object *obj);
+void ebpf_object_close(struct bpf_object *obj);
 #endif

--- a/non-GPL/HostIsolationMapsUtil/UpdateIPsDemo.c
+++ b/non-GPL/HostIsolationMapsUtil/UpdateIPsDemo.c
@@ -1,52 +1,47 @@
 // SPDX-License-Identifier: LicenseRef-Elastic-License-2.0
 
 /*
- * Copyright 2021 Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the Elastic License 2.0;
- * you may not use this file except in compliance with the Elastic License 2.0.
+ * Copyright 2021 Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under
+ * one or more contributor license agreements. Licensed under the Elastic
+ * License 2.0; you may not use this file except in compliance with the Elastic
+ * License 2.0.
  */
-
 
 //
 // Host Isolation - tool for updating maps of allowed IPs and subnets
 //
+#include <Common.h>
 #include <argp.h>
-#include <unistd.h>
+#include <arpa/inet.h>
 #include <stdlib.h>
 #include <time.h>
-#include <arpa/inet.h>
+#include <unistd.h>
 
-#include <Common.h>
 #include "UpdateMaps.h"
 
-int
-main(int argc,
-     char **argv)
+int main(int argc, char **argv)
 {
-    int rv = 0;
+    int rv          = 0;
     uint32_t IPaddr = 0;
     char IP_str[64] = {0};
-    char *str_ptr = NULL;
-    char *str_end = NULL;
-    long netmask = 0;
+    char *str_ptr   = NULL;
+    char *str_end   = NULL;
+    long netmask    = 0;
 
     ebpf_set_log_func(ebpf_default_log_func());
 
-    if (2 != argc)
-    {
+    if (2 != argc) {
         printf("You need to pass an IPv4 address as an argument\n");
         rv = -1;
         goto cleanup;
     }
 
     str_ptr = strstr(argv[1], "/");
-    if (str_ptr && (str_ptr[1] != '\0'))
-    {
+    if (str_ptr && (str_ptr[1] != '\0')) {
         /* An IP with subnet mask was given - add to allowed subnets map */
         memset(IP_str, 0, sizeof(IP_str));
         memcpy(IP_str, argv[1], (str_ptr - argv[1]));
-        if (!inet_pton(AF_INET, IP_str, &IPaddr))
-        {
+        if (!inet_pton(AF_INET, IP_str, &IPaddr)) {
             printf("Error: given IP is invalid\n");
             rv = -1;
             goto cleanup;
@@ -54,23 +49,20 @@ main(int argc,
 
         str_ptr++;
         netmask = strtol(str_ptr, &str_end, 10);
-        if (str_end == str_ptr || netmask > 32 || netmask < 0)
-        {
+        if (str_end == str_ptr || netmask > 32 || netmask < 0) {
             printf("Error parsing subnet mask\n");
             rv = -1;
             goto cleanup;
         }
 
         rv = ebpf_map_allowed_subnets_add(IPaddr, netmask);
-        if (0 == rv)
-        {
-            printf("IP subnet %s added to " EBPF_ALLOWED_SUBNETS_MAP_NAME " BPF map!\n", argv[1]);
+        if (0 == rv) {
+            printf("IP subnet %s added to " EBPF_ALLOWED_SUBNETS_MAP_NAME
+                   " BPF map!\n",
+                   argv[1]);
         }
-    }
-    else
-    {
-        if (!inet_pton(AF_INET, argv[1], &IPaddr))
-        {
+    } else {
+        if (!inet_pton(AF_INET, argv[1], &IPaddr)) {
             printf("Error: given IP is invalid\n");
             rv = -1;
             goto cleanup;
@@ -78,9 +70,9 @@ main(int argc,
 
         /* An IP with no subnet was given - add to allowed_IPs */
         rv = ebpf_map_allowed_IPs_add(IPaddr);
-        if (0 == rv)
-        {
-            printf("IP %s added to " EBPF_ALLOWED_IPS_MAP_NAME " BPF map!\n", argv[1]);
+        if (0 == rv) {
+            printf("IP %s added to " EBPF_ALLOWED_IPS_MAP_NAME " BPF map!\n",
+                   argv[1]);
         }
     }
 
@@ -88,4 +80,3 @@ cleanup:
 
     return rv;
 }
-

--- a/non-GPL/HostIsolationMapsUtil/UpdateIPsDemo.c
+++ b/non-GPL/HostIsolationMapsUtil/UpdateIPsDemo.c
@@ -57,9 +57,7 @@ int main(int argc, char **argv)
 
         rv = ebpf_map_allowed_subnets_add(IPaddr, netmask);
         if (0 == rv) {
-            printf("IP subnet %s added to " EBPF_ALLOWED_SUBNETS_MAP_NAME
-                   " BPF map!\n",
-                   argv[1]);
+            printf("IP subnet %s added to " EBPF_ALLOWED_SUBNETS_MAP_NAME " BPF map!\n", argv[1]);
         }
     } else {
         if (!inet_pton(AF_INET, argv[1], &IPaddr)) {
@@ -71,8 +69,7 @@ int main(int argc, char **argv)
         /* An IP with no subnet was given - add to allowed_IPs */
         rv = ebpf_map_allowed_IPs_add(IPaddr);
         if (0 == rv) {
-            printf("IP %s added to " EBPF_ALLOWED_IPS_MAP_NAME " BPF map!\n",
-                   argv[1]);
+            printf("IP %s added to " EBPF_ALLOWED_IPS_MAP_NAME " BPF map!\n", argv[1]);
         }
     }
 

--- a/non-GPL/HostIsolationMapsUtil/UpdateMaps.c
+++ b/non-GPL/HostIsolationMapsUtil/UpdateMaps.c
@@ -26,16 +26,14 @@ static int ebpf_update_map(const char *map_path,
                            const void *key,
                            const void *val);
 static int ebpf_create_map(enum ebpf_hostisolation_map map_id, int *map_fd);
-static int ebpf_clear_map(const char *map_path,
-                          enum ebpf_hostisolation_map map_id);
+static int ebpf_clear_map(const char *map_path, enum ebpf_hostisolation_map map_id);
 
 int ebpf_map_allowed_IPs_add(uint32_t IPaddr)
 {
     uint32_t key = IPaddr;
     uint32_t val = 1; // values are not used in the hash map
 
-    return ebpf_update_map(EBPF_ALLOWED_IPS_MAP_PATH, EBPF_MAP_ALLOWED_IPS,
-                           &key, &val);
+    return ebpf_update_map(EBPF_ALLOWED_IPS_MAP_PATH, EBPF_MAP_ALLOWED_IPS, &key, &val);
 }
 
 int ebpf_map_allowed_subnets_add(uint32_t IPaddr, uint32_t netmask)
@@ -49,8 +47,7 @@ int ebpf_map_allowed_subnets_add(uint32_t IPaddr, uint32_t netmask)
     };
     uint32_t val = 1; // values are not used in the lpm trie map
 
-    return ebpf_update_map(EBPF_ALLOWED_SUBNETS_MAP_PATH,
-                           EBPF_MAP_ALLOWED_SUBNETS, &key, &val);
+    return ebpf_update_map(EBPF_ALLOWED_SUBNETS_MAP_PATH, EBPF_MAP_ALLOWED_SUBNETS, &key, &val);
 }
 
 int ebpf_map_allowed_pids_add(uint32_t pid)
@@ -58,8 +55,7 @@ int ebpf_map_allowed_pids_add(uint32_t pid)
     uint32_t key = pid;
     uint32_t val = 1; // values are not used in the hash map
 
-    return ebpf_update_map(EBPF_ALLOWED_PIDS_MAP_PATH, EBPF_MAP_ALLOWED_PIDS,
-                           &key, &val);
+    return ebpf_update_map(EBPF_ALLOWED_PIDS_MAP_PATH, EBPF_MAP_ALLOWED_PIDS, &key, &val);
 }
 
 int ebpf_map_allowed_IPs_clear()
@@ -69,8 +65,7 @@ int ebpf_map_allowed_IPs_clear()
 
 int ebpf_map_allowed_subnets_clear()
 {
-    return ebpf_clear_map(EBPF_ALLOWED_SUBNETS_MAP_PATH,
-                          EBPF_MAP_ALLOWED_SUBNETS);
+    return ebpf_clear_map(EBPF_ALLOWED_SUBNETS_MAP_PATH, EBPF_MAP_ALLOWED_SUBNETS);
 }
 
 int ebpf_map_allowed_pids_clear()
@@ -90,8 +85,7 @@ static int ebpf_create_map(enum ebpf_hostisolation_map map_id, int *map_fd)
     }
 
     fd = bpf_create_map(ebpf_maps[map_id].type, ebpf_maps[map_id].key_size,
-                        ebpf_maps[map_id].value_size,
-                        ebpf_maps[map_id].max_entries,
+                        ebpf_maps[map_id].value_size, ebpf_maps[map_id].max_entries,
                         ebpf_maps[map_id].map_flags);
 
     if (fd < 0) {
@@ -125,24 +119,19 @@ static int ebpf_update_map(const char *map_path,
         // perhaps the map does not exist, try to create it and pin to bpf fs
         rv = ebpf_create_map(map_id, &map_fd);
         if (rv) {
-            ebpf_log(
-                "Error updating map, make sure to run with sudo. Errno=%d\n",
-                errno);
+            ebpf_log("Error updating map, make sure to run with sudo. Errno=%d\n", errno);
             goto cleanup;
         }
         rv = bpf_obj_pin(map_fd, map_path);
         if (rv) {
-            ebpf_log(
-                "Error pinning map, make sure to run with sudo. Errno=%d\n",
-                errno);
+            ebpf_log("Error pinning map, make sure to run with sudo. Errno=%d\n", errno);
             goto cleanup;
         }
     }
 
     rv = bpf_map_update_elem(map_fd, key, val, 0);
     if (rv) {
-        ebpf_log("Error: failed to add entry to map: %s, errno=%d\n", map_path,
-                 errno);
+        ebpf_log("Error: failed to add entry to map: %s, errno=%d\n", map_path, errno);
         goto cleanup;
     }
 
@@ -154,8 +143,7 @@ cleanup:
     return rv;
 }
 
-static int ebpf_clear_map(const char *map_path,
-                          enum ebpf_hostisolation_map map_id)
+static int ebpf_clear_map(const char *map_path, enum ebpf_hostisolation_map map_id)
 {
     int rv                   = 0;
     int map_fd               = -1;
@@ -173,9 +161,7 @@ static int ebpf_clear_map(const char *map_path,
         // perhaps the map does not exist, try to create it
         rv = ebpf_create_map(map_id, &map_fd);
         if (rv) {
-            ebpf_log(
-                "Error clearing map, make sure to run with sudo. Errno=%d\n",
-                errno);
+            ebpf_log("Error clearing map, make sure to run with sudo. Errno=%d\n", errno);
             goto cleanup;
         }
     }

--- a/non-GPL/HostIsolationMapsUtil/UpdateMaps.c
+++ b/non-GPL/HostIsolationMapsUtil/UpdateMaps.c
@@ -1,113 +1,100 @@
 // SPDX-License-Identifier: LicenseRef-Elastic-License-2.0
 
 /*
- * Copyright 2021 Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the Elastic License 2.0;
- * you may not use this file except in compliance with the Elastic License 2.0.
+ * Copyright 2021 Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under
+ * one or more contributor license agreements. Licensed under the Elastic
+ * License 2.0; you may not use this file except in compliance with the Elastic
+ * License 2.0.
  */
-
 
 //
 // Host Isolation - tool for updating maps of allowed IPs, subnets and pids
 //
+#include "UpdateMaps.h"
+
+#include <Common.h>
 #include <argp.h>
-#include <unistd.h>
-#include <time.h>
-#include <errno.h>
 #include <arpa/inet.h>
 #include <bpf/bpf.h>
 #include <bpf/libbpf.h>
+#include <errno.h>
+#include <time.h>
+#include <unistd.h>
 
-#include <Common.h>
-#include "UpdateMaps.h"
+static int ebpf_update_map(const char *map_path,
+                           enum ebpf_hostisolation_map map_id,
+                           const void *key,
+                           const void *val);
+static int ebpf_create_map(enum ebpf_hostisolation_map map_id, int *map_fd);
+static int ebpf_clear_map(const char *map_path,
+                          enum ebpf_hostisolation_map map_id);
 
-static int
-ebpf_update_map(const char *map_path,
-                enum ebpf_hostisolation_map map_id,
-                const void *key,
-                const void *val);
-static int
-ebpf_create_map(enum ebpf_hostisolation_map map_id,
-                int *map_fd);
-static int
-ebpf_clear_map(const char *map_path,
-                enum ebpf_hostisolation_map map_id);
-
-int
-ebpf_map_allowed_IPs_add(uint32_t IPaddr)
+int ebpf_map_allowed_IPs_add(uint32_t IPaddr)
 {
     uint32_t key = IPaddr;
-    uint32_t val = 1;   // values are not used in the hash map
+    uint32_t val = 1; // values are not used in the hash map
 
-    return ebpf_update_map(EBPF_ALLOWED_IPS_MAP_PATH, EBPF_MAP_ALLOWED_IPS, &key, &val);
+    return ebpf_update_map(EBPF_ALLOWED_IPS_MAP_PATH, EBPF_MAP_ALLOWED_IPS,
+                           &key, &val);
 }
 
-int
-ebpf_map_allowed_subnets_add(uint32_t IPaddr, uint32_t netmask)
+int ebpf_map_allowed_subnets_add(uint32_t IPaddr, uint32_t netmask)
 {
-    struct lpm_key
-    {
+    struct lpm_key {
         uint32_t prefix;
         uint32_t IP;
-    } key =
-    {
+    } key = {
         .prefix = netmask,
-        .IP = IPaddr,
+        .IP     = IPaddr,
     };
-    uint32_t val = 1;   // values are not used in the lpm trie map
+    uint32_t val = 1; // values are not used in the lpm trie map
 
-    return ebpf_update_map(EBPF_ALLOWED_SUBNETS_MAP_PATH, EBPF_MAP_ALLOWED_SUBNETS, &key, &val);
+    return ebpf_update_map(EBPF_ALLOWED_SUBNETS_MAP_PATH,
+                           EBPF_MAP_ALLOWED_SUBNETS, &key, &val);
 }
 
-int
-ebpf_map_allowed_pids_add(uint32_t pid)
+int ebpf_map_allowed_pids_add(uint32_t pid)
 {
     uint32_t key = pid;
-    uint32_t val = 1;   // values are not used in the hash map
+    uint32_t val = 1; // values are not used in the hash map
 
-    return ebpf_update_map(EBPF_ALLOWED_PIDS_MAP_PATH, EBPF_MAP_ALLOWED_PIDS, &key, &val);
+    return ebpf_update_map(EBPF_ALLOWED_PIDS_MAP_PATH, EBPF_MAP_ALLOWED_PIDS,
+                           &key, &val);
 }
 
-int
-ebpf_map_allowed_IPs_clear()
+int ebpf_map_allowed_IPs_clear()
 {
     return ebpf_clear_map(EBPF_ALLOWED_IPS_MAP_PATH, EBPF_MAP_ALLOWED_IPS);
 }
 
-int
-ebpf_map_allowed_subnets_clear()
+int ebpf_map_allowed_subnets_clear()
 {
-    return ebpf_clear_map(EBPF_ALLOWED_SUBNETS_MAP_PATH, EBPF_MAP_ALLOWED_SUBNETS);
+    return ebpf_clear_map(EBPF_ALLOWED_SUBNETS_MAP_PATH,
+                          EBPF_MAP_ALLOWED_SUBNETS);
 }
 
-int
-ebpf_map_allowed_pids_clear()
+int ebpf_map_allowed_pids_clear()
 {
     return ebpf_clear_map(EBPF_ALLOWED_PIDS_MAP_PATH, EBPF_MAP_ALLOWED_PIDS);
 }
 
-static int
-ebpf_create_map(enum ebpf_hostisolation_map map_id,
-                int *map_fd)
+static int ebpf_create_map(enum ebpf_hostisolation_map map_id, int *map_fd)
 {
     int rv = 0;
     int fd = -1;
 
-    if (map_id >= EBPF_MAP_NUM)
-    {
+    if (map_id >= EBPF_MAP_NUM) {
         ebpf_log("Error: invalid map ID\n");
         rv = -1;
         goto cleanup;
     }
 
-    fd = bpf_create_map(ebpf_maps[map_id].type,
-                        ebpf_maps[map_id].key_size,
+    fd = bpf_create_map(ebpf_maps[map_id].type, ebpf_maps[map_id].key_size,
                         ebpf_maps[map_id].value_size,
                         ebpf_maps[map_id].max_entries,
                         ebpf_maps[map_id].map_flags);
 
-    if (fd < 0)
-    {
+    if (fd < 0) {
         ebpf_log("Error creating map\n");
         rv = -1;
         goto cleanup;
@@ -119,102 +106,98 @@ cleanup:
     return rv;
 }
 
-static int
-ebpf_update_map(const char *map_path, enum ebpf_hostisolation_map map_id, const void *key, const void *val)
+static int ebpf_update_map(const char *map_path,
+                           enum ebpf_hostisolation_map map_id,
+                           const void *key,
+                           const void *val)
 {
-    int rv = 0;
+    int rv     = 0;
     int map_fd = -1;
 
-    if (map_path == NULL)
-    {
+    if (map_path == NULL) {
         ebpf_log("Error: map_path is NULL\n");
         rv = -1;
         goto cleanup;
     }
 
     map_fd = bpf_obj_get(map_path);
-    if (map_fd < 0)
-    {
+    if (map_fd < 0) {
         // perhaps the map does not exist, try to create it and pin to bpf fs
         rv = ebpf_create_map(map_id, &map_fd);
-        if (rv)
-        {
-            ebpf_log("Error updating map, make sure to run with sudo. Errno=%d\n", errno);
+        if (rv) {
+            ebpf_log(
+                "Error updating map, make sure to run with sudo. Errno=%d\n",
+                errno);
             goto cleanup;
         }
         rv = bpf_obj_pin(map_fd, map_path);
-        if (rv)
-        {
-            ebpf_log("Error pinning map, make sure to run with sudo. Errno=%d\n", errno);
+        if (rv) {
+            ebpf_log(
+                "Error pinning map, make sure to run with sudo. Errno=%d\n",
+                errno);
             goto cleanup;
         }
     }
 
     rv = bpf_map_update_elem(map_fd, key, val, 0);
-    if (rv)
-    {
-        ebpf_log("Error: failed to add entry to map: %s, errno=%d\n", map_path, errno);
+    if (rv) {
+        ebpf_log("Error: failed to add entry to map: %s, errno=%d\n", map_path,
+                 errno);
         goto cleanup;
     }
 
 cleanup:
-    if (map_fd >= 0)
-    {
+    if (map_fd >= 0) {
         close(map_fd);
     }
 
     return rv;
 }
 
-static int
-ebpf_clear_map(const char *map_path,
-               enum ebpf_hostisolation_map map_id)
+static int ebpf_clear_map(const char *map_path,
+                          enum ebpf_hostisolation_map map_id)
 {
-    int rv = 0;
-    int map_fd = -1;
-    uint8_t key_buf[64] = {0};
+    int rv                   = 0;
+    int map_fd               = -1;
+    uint8_t key_buf[64]      = {0};
     uint8_t next_key_buf[64] = {0};
 
-    if (map_path == NULL)
-    {
+    if (map_path == NULL) {
         ebpf_log("Error: map_path is NULL\n");
         rv = -1;
         goto cleanup;
     }
 
     map_fd = bpf_obj_get(map_path);
-    if (map_fd < 0)
-    {
+    if (map_fd < 0) {
         // perhaps the map does not exist, try to create it
         rv = ebpf_create_map(map_id, &map_fd);
-        if (rv)
-        {
-            ebpf_log("Error clearing map, make sure to run with sudo. Errno=%d\n", errno);
+        if (rv) {
+            ebpf_log(
+                "Error clearing map, make sure to run with sudo. Errno=%d\n",
+                errno);
             goto cleanup;
         }
     }
 
     // get the first key
-    if (bpf_map_get_next_key(map_fd, NULL, key_buf) < 0)
-    {
+    if (bpf_map_get_next_key(map_fd, NULL, key_buf) < 0) {
         // map is already empty
         goto cleanup;
     }
 
     // iterate over map
-    while (0 == bpf_map_get_next_key(map_fd, key_buf, next_key_buf))
-    {
+    while (0 == bpf_map_get_next_key(map_fd, key_buf, next_key_buf)) {
         // return value 0 means 'key' exists and 'next_key' has been set
         (void)bpf_map_delete_elem(map_fd, key_buf);
-	memcpy(key_buf, next_key_buf, sizeof(key_buf));
+        memcpy(key_buf, next_key_buf, sizeof(key_buf));
     }
 
     // -1 was returned so 'key' is the last element - delete it
     (void)bpf_map_delete_elem(map_fd, key_buf);
 
 cleanup:
-    if (map_fd >= 0)
-    {
+    if (map_fd >= 0) {
         close(map_fd);
     }
 

--- a/non-GPL/HostIsolationMapsUtil/UpdateMaps.h
+++ b/non-GPL/HostIsolationMapsUtil/UpdateMaps.h
@@ -1,9 +1,10 @@
 // SPDX-License-Identifier: LicenseRef-Elastic-License-2.0
 
 /*
- * Copyright 2021 Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the Elastic License 2.0;
- * you may not use this file except in compliance with the Elastic License 2.0.
+ * Copyright 2021 Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under
+ * one or more contributor license agreements. Licensed under the Elastic
+ * License 2.0; you may not use this file except in compliance with the Elastic
+ * License 2.0.
  */
 
 #ifndef EBPF_UPDATE_MAPS_H
@@ -19,8 +20,7 @@
  * @param[in] IPaddr IP address in uint format
  * @return Error value (0 for success)
  */
-int
-ebpf_map_allowed_IPs_add(uint32_t IPaddr);
+int ebpf_map_allowed_IPs_add(uint32_t IPaddr);
 
 /**
  * @brief Add an IP subnet to the subnet allowlist
@@ -29,8 +29,7 @@ ebpf_map_allowed_IPs_add(uint32_t IPaddr);
  * @param[in] netmask subnet mask in uint format (0-32)
  * @return Error value (0 for success)
  */
-int
-ebpf_map_allowed_subnets_add(uint32_t IPaddr, uint32_t netmask);
+int ebpf_map_allowed_subnets_add(uint32_t IPaddr, uint32_t netmask);
 
 /**
  * @brief Add a single PID (process ID) to the PID allowlist
@@ -38,30 +37,26 @@ ebpf_map_allowed_subnets_add(uint32_t IPaddr, uint32_t netmask);
  * @param[in] pid PID number
  * @return Error value (0 for success)
  */
-int
-ebpf_map_allowed_pids_add(uint32_t pid);
+int ebpf_map_allowed_pids_add(uint32_t pid);
 
 /**
  * @brief Clear IP allowlist
  *
  * @return Error value (0 for success)
  */
-int
-ebpf_map_allowed_IPs_clear();
+int ebpf_map_allowed_IPs_clear();
 
 /**
  * @brief Clear IP subnet allowlist
  *
  * @return Error value (0 for success)
  */
-int
-ebpf_map_allowed_subnets_clear();
+int ebpf_map_allowed_subnets_clear();
 
 /**
  * @brief Clear pid allowlist
  *
  * @return Error value (0 for success)
  */
-int
-ebpf_map_allowed_pids_clear();
+int ebpf_map_allowed_pids_clear();
 #endif

--- a/non-GPL/HostIsolationMapsUtil/UpdateMaps.h
+++ b/non-GPL/HostIsolationMapsUtil/UpdateMaps.h
@@ -10,6 +10,8 @@
 #ifndef EBPF_UPDATE_MAPS_H
 #define EBPF_UPDATE_MAPS_H
 
+#include <stdint.h>
+
 //
 // Host Isolation - tool for updating maps of allowed IPs, subnets and pids
 //

--- a/non-GPL/HostIsolationMapsUtil/UpdatePidsDemo.c
+++ b/non-GPL/HostIsolationMapsUtil/UpdatePidsDemo.c
@@ -1,41 +1,37 @@
 // SPDX-License-Identifier: LicenseRef-Elastic-License-2.0
 
 /*
- * Copyright 2021 Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the Elastic License 2.0;
- * you may not use this file except in compliance with the Elastic License 2.0.
+ * Copyright 2021 Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under
+ * one or more contributor license agreements. Licensed under the Elastic
+ * License 2.0; you may not use this file except in compliance with the Elastic
+ * License 2.0.
  */
-
 
 //
 // Host Isolation - tool for updating map of allowed PIDs
 //
-#include <argp.h>
-#include <unistd.h>
-#include <time.h>
-#include <arpa/inet.h>
-
 #include <Common.h>
+#include <argp.h>
+#include <arpa/inet.h>
+#include <time.h>
+#include <unistd.h>
+
 #include "UpdateMaps.h"
 
-int
-main(int argc,
-     char **argv)
+int main(int argc, char **argv)
 {
-    int rv = 0;
+    int rv       = 0;
     uint32_t pid = 0;
 
     ebpf_set_log_func(ebpf_default_log_func());
 
-    if (2 != argc)
-    {
+    if (2 != argc) {
         printf("You need to pass a PID number as an argument\n");
         rv = -1;
         goto cleanup;
     }
 
-    if (sscanf(argv[1], "%u", &pid) != 1)
-    {
+    if (sscanf(argv[1], "%u", &pid) != 1) {
         printf("Error parsing string\n");
         rv = -1;
         goto cleanup;
@@ -44,7 +40,8 @@ main(int argc,
     rv = ebpf_map_allowed_pids_add(pid);
 
     if (0 == rv)
-        printf("PID %u added to " EBPF_ALLOWED_PIDS_MAP_NAME " BPF map!\n", pid);
+        printf("PID %u added to " EBPF_ALLOWED_PIDS_MAP_NAME " BPF map!\n",
+               pid);
 
 cleanup:
 

--- a/non-GPL/HostIsolationMapsUtil/UpdatePidsDemo.c
+++ b/non-GPL/HostIsolationMapsUtil/UpdatePidsDemo.c
@@ -40,8 +40,7 @@ int main(int argc, char **argv)
     rv = ebpf_map_allowed_pids_add(pid);
 
     if (0 == rv)
-        printf("PID %u added to " EBPF_ALLOWED_PIDS_MAP_NAME " BPF map!\n",
-               pid);
+        printf("PID %u added to " EBPF_ALLOWED_PIDS_MAP_NAME " BPF map!\n", pid);
 
 cleanup:
 

--- a/non-GPL/LibEbpfEvents/LibEbpfEvents.c
+++ b/non-GPL/LibEbpfEvents/LibEbpfEvents.c
@@ -58,9 +58,9 @@ int ebpf_event_ctx__new(struct ebpf_event_ctx **ctx,
         goto out_destroy_probe;
 
     struct ring_buffer_opts opts;
-    opts.sz         = sizeof(opts);
-    (*ctx)->ringbuf = ring_buffer__new(bpf_map__fd((*ctx)->probe->maps.ringbuf),
-                                       ring_buf_cb, cb, &opts);
+    opts.sz = sizeof(opts);
+    (*ctx)->ringbuf =
+        ring_buffer__new(bpf_map__fd((*ctx)->probe->maps.ringbuf), ring_buf_cb, cb, &opts);
 
     if ((*ctx)->ringbuf == NULL) {
         /* ring_buffer__new doesn't report errors, hard to find something that

--- a/non-GPL/LibEbpfEvents/LibEbpfEvents.h
+++ b/non-GPL/LibEbpfEvents/LibEbpfEvents.h
@@ -11,6 +11,7 @@
 #define EBPF_EVENTS_H_
 
 #include <stddef.h>
+
 #include "EbpfEventProto.h"
 
 enum ebpf_kernel_features {
@@ -29,19 +30,16 @@ typedef int (*ebpf_event_handler_fn)(struct ebpf_event_header *);
  * returns a positive int that represents an fd, which can be used with epoll
  * on success. returns an error on failure.
  */
-int ebpf_event_ctx__new(
-        struct ebpf_event_ctx **ctx,
-        ebpf_event_handler_fn cb,
-        uint64_t features,
-        uint64_t events);
+int ebpf_event_ctx__new(struct ebpf_event_ctx **ctx,
+                        ebpf_event_handler_fn cb,
+                        uint64_t features,
+                        uint64_t events);
 
 /* Consumes as many events as possible from the event context and returns the
  * number consumed.
  */
-int ebpf_event_ctx__next(
-        struct ebpf_event_ctx *ctx, int timeout);
+int ebpf_event_ctx__next(struct ebpf_event_ctx *ctx, int timeout);
 
-void ebpf_event_ctx__destroy(
-        struct ebpf_event_ctx *ctx);
+void ebpf_event_ctx__destroy(struct ebpf_event_ctx *ctx);
 
 #endif // EBPF_EVENTS_H_

--- a/non-GPL/TcLoader/TcLoader.c
+++ b/non-GPL/TcLoader/TcLoader.c
@@ -1,47 +1,45 @@
 // SPDX-License-Identifier: LicenseRef-Elastic-License-2.0
 
 /*
- * Copyright 2021 Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the Elastic License 2.0;
- * you may not use this file except in compliance with the Elastic License 2.0.
+ * Copyright 2021 Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under
+ * one or more contributor license agreements. Licensed under the Elastic
+ * License 2.0; you may not use this file except in compliance with the Elastic
+ * License 2.0.
  */
-
 
 //
 // Loader for tc eBPF programs
-// 
-#include <stdio.h>
-#include <stdlib.h>
-#include <argp.h>
-#include <unistd.h>
-#include <time.h>
-#include <fcntl.h>
-#include <string.h>
-
-#include <sys/socket.h>
-#include <sys/stat.h>
+//
+#include "TcLoader.h"
 
 #include <Common.h>
-#include "TcLoader.h"
+#include <argp.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <sys/stat.h>
+#include <time.h>
+#include <unistd.h>
 
 /* linux definitions */
 #define SOL_NETLINK 270
 #define NETLINK_EXT_ACK 11
 
-#define ETH_P_ALL   0x0003      /* Every packet */
+#define ETH_P_ALL 0x0003 /* Every packet */
 
 #define TC_H_MAJ_MASK (0xFFFF0000U)
 #define TC_H_MIN_MASK (0x0000FFFFU)
 #define TC_H_MAJ(h) ((h)&TC_H_MAJ_MASK)
 #define TC_H_MIN(h) ((h)&TC_H_MIN_MASK)
-#define TC_H_MAKE(maj,min) (((maj)&TC_H_MAJ_MASK)|((min)&TC_H_MIN_MASK))
-#define TC_H_INGRESS    (0xFFFFFFF1U)
-#define TC_H_CLSACT     TC_H_INGRESS
-#define TC_H_MIN_EGRESS         0xFFF3U
-#define TCA_BPF_FLAG_ACT_DIRECT     (1 << 0)
+#define TC_H_MAKE(maj, min) (((maj)&TC_H_MAJ_MASK) | ((min)&TC_H_MIN_MASK))
+#define TC_H_INGRESS (0xFFFFFFF1U)
+#define TC_H_CLSACT TC_H_INGRESS
+#define TC_H_MIN_EGRESS 0xFFF3U
+#define TCA_BPF_FLAG_ACT_DIRECT (1 << 0)
 
-enum
-{
+enum {
     TCA_BPF_UNSPEC,
     TCA_BPF_ACT,
     TCA_BPF_POLICE,
@@ -57,88 +55,68 @@ enum
     __TCA_BPF_MAX,
 };
 
-#define NLMSG_TAIL(nmsg) \
-    ((struct rtattr *) (((void *) (nmsg)) + NLMSG_ALIGN((nmsg)->nlmsg_len)))
-
+#define NLMSG_TAIL(nmsg)                                                       \
+    ((struct rtattr *)(((void *)(nmsg)) + NLMSG_ALIGN((nmsg)->nlmsg_len)))
 
 static int
-attr_put(struct nlmsghdr *n,
-         int max,
-         int type,
-         const void *buf,
-         int attr_len)
+attr_put(struct nlmsghdr *n, int max, int type, const void *buf, int attr_len)
 {
-    int len = RTA_LENGTH(attr_len);
+    int len            = RTA_LENGTH(attr_len);
     struct rtattr *rta = NULL;
-    int rv = -1;
+    int rv             = -1;
 
-    if (NLMSG_ALIGN(n->nlmsg_len) + RTA_ALIGN(len) > max)
-    {
+    if (NLMSG_ALIGN(n->nlmsg_len) + RTA_ALIGN(len) > max) {
         ebpf_log("attr_put error: message longer than %d\n", max);
         rv = -1;
         goto out;
     }
 
-    rta = NLMSG_TAIL(n);
-    rta->rta_len = len;
+    rta           = NLMSG_TAIL(n);
+    rta->rta_len  = len;
     rta->rta_type = type;
 
-    if (attr_len)
-    {
+    if (attr_len) {
         memcpy(RTA_DATA(rta), buf, attr_len);
     }
 
     n->nlmsg_len = NLMSG_ALIGN(n->nlmsg_len) + RTA_ALIGN(len);
-    rv = 0;
+    rv           = 0;
 out:
     return rv;
 }
 
-static int
-attr_put_32(struct nlmsghdr *n,
-            int max,
-            int type,
-            __u32 data)
+static int attr_put_32(struct nlmsghdr *n, int max, int type, __u32 data)
 {
     return attr_put(n, max, type, &data, sizeof(__u32));
 }
 
-static int
-attr_put_str(struct nlmsghdr *n,
-             int max,
-             int type,
-             const char *s)
+static int attr_put_str(struct nlmsghdr *n, int max, int type, const char *s)
 {
-    return attr_put(n, max, type, s, strlen(s)+1);
+    return attr_put(n, max, type, s, strlen(s) + 1);
 }
 
-static void
-rtnetlink_close(struct rtnetlink_handle *r)
+static void rtnetlink_close(struct rtnetlink_handle *r)
 {
-    if (r->fd >= 0)
-    {
+    if (r->fd >= 0) {
         close(r->fd);
         r->fd = -1;
     }
 }
 
-static void
-rtnetlink_send_error(struct nlmsgerr *err)
+static void rtnetlink_send_error(struct nlmsgerr *err)
 {
     ebpf_log("rtnetlink replied: %s\n", strerror(-err->error));
 }
 
-static int
-rtnetlink_open(struct rtnetlink_handle *rth)
+static int rtnetlink_open(struct rtnetlink_handle *rth)
 {
     socklen_t address_len = 0;
-    int sendbuf = 32 * 1024;
-    int receivebuf = 1024 * 1024;
-    int one = 1;
-    int rv = -1;
+    int sendbuf           = 32 * 1024;
+    int receivebuf        = 1024 * 1024;
+    int one               = 1;
+    int rv                = -1;
 
-    if (rth == NULL)
-    {
+    if (rth == NULL) {
         ebpf_log("error: rth is NULL\n");
         rv = -1;
         goto out;
@@ -147,33 +125,28 @@ rtnetlink_open(struct rtnetlink_handle *rth)
     memset(rth, 0, sizeof(*rth));
 
     rth->proto = NETLINK_ROUTE;
-    rth->fd = socket(AF_NETLINK, SOCK_RAW | SOCK_CLOEXEC, NETLINK_ROUTE);
-    if (rth->fd < 0)
-    {
+    rth->fd    = socket(AF_NETLINK, SOCK_RAW | SOCK_CLOEXEC, NETLINK_ROUTE);
+    if (rth->fd < 0) {
         ebpf_log("cannot open netlink socket\n");
         rv = -1;
         goto out;
     }
 
-    if (setsockopt(rth->fd, SOL_SOCKET, SO_SNDBUF,
-               &sendbuf, sizeof(sendbuf)) < 0)
-    {
+    if (setsockopt(rth->fd, SOL_SOCKET, SO_SNDBUF, &sendbuf, sizeof(sendbuf)) <
+        0) {
         ebpf_log("error setsockopt sendbuf\n");
         rv = -1;
         goto out;
     }
 
-    if (setsockopt(rth->fd, SOL_SOCKET, SO_RCVBUF,
-               &receivebuf, sizeof(receivebuf)) < 0)
-    {
+    if (setsockopt(rth->fd, SOL_SOCKET, SO_RCVBUF, &receivebuf,
+                   sizeof(receivebuf)) < 0) {
         ebpf_log("error setsockopt receivebuf\n");
         rv = -1;
         goto out;
     }
 
-    if (setsockopt(rth->fd, SOL_NETLINK, NETLINK_EXT_ACK,
-           &one, sizeof(one)))
-    {
+    if (setsockopt(rth->fd, SOL_NETLINK, NETLINK_EXT_ACK, &one, sizeof(one))) {
         ebpf_log("error setsockopt netlink\n");
         rv = -1;
         goto out;
@@ -184,109 +157,90 @@ rtnetlink_open(struct rtnetlink_handle *rth)
     rth->local.nl_family = AF_NETLINK;
     rth->local.nl_groups = 0;
 
-    if (bind(rth->fd, (struct sockaddr *)&rth->local,
-         sizeof(rth->local)) < 0)
-    {
+    if (bind(rth->fd, (struct sockaddr *)&rth->local, sizeof(rth->local)) < 0) {
         ebpf_log("failed to bind netlink socket\n");
         rv = -1;
         goto out;
     }
     address_len = sizeof(rth->local);
-    if (getsockname(rth->fd, (struct sockaddr *)&rth->local,
-            &address_len) < 0)
-    {
+    if (getsockname(rth->fd, (struct sockaddr *)&rth->local, &address_len) <
+        0) {
         ebpf_log("error getsockname\n");
         rv = -1;
         goto out;
     }
-    if (address_len != sizeof(rth->local))
-    {
+    if (address_len != sizeof(rth->local)) {
         ebpf_log("bad address length %d\n", address_len);
         rv = -1;
         goto out;
     }
-    if (rth->local.nl_family != AF_NETLINK)
-    {
-        ebpf_log("bad address family %d\n",
-            rth->local.nl_family);
+    if (rth->local.nl_family != AF_NETLINK) {
+        ebpf_log("bad address family %d\n", rth->local.nl_family);
         rv = -1;
         goto out;
     }
 
     rth->seq = time(NULL);
-    rv = 0;
+    rv       = 0;
 out:
     return rv;
 }
 
-static int
-rtnetlink_recv(int fd, 
-               struct msghdr *msg,
-               char **answer)
+static int rtnetlink_recv(int fd, struct msghdr *msg, char **answer)
 {
     struct iovec *iov = NULL;
-    char *buf = NULL;
-    int len = 0;
-    int rv = 0;
+    char *buf         = NULL;
+    int len           = 0;
+    int rv            = 0;
 
-    if (!msg)
-    {
+    if (!msg) {
         ebpf_log("rtnetlink_recv error: NULL parameter\n");
         rv = -1;
         goto out;
     }
 
-    iov = msg->msg_iov;
+    iov           = msg->msg_iov;
     iov->iov_base = NULL;
-    iov->iov_len = 0;
+    iov->iov_len  = 0;
 
-    do
-    {
+    do {
         len = recvmsg(fd, msg, MSG_PEEK | MSG_TRUNC);
     } while (len < 0 && (errno == EINTR || errno == EAGAIN));
 
-    if (len <= 0)
-    {
+    if (len <= 0) {
         ebpf_log("netlink recv error \n");
         rv = len;
         goto out;
     }
 
-    if (len < 32768)
-    {
+    if (len < 32768) {
         len = 32768;
     }
 
     buf = malloc(len);
-    if (!buf)
-    {
+    if (!buf) {
         ebpf_log("malloc error \n");
         rv = -ENOMEM;
         goto out;
     }
 
     iov->iov_base = buf;
-    iov->iov_len = len;
+    iov->iov_len  = len;
 
-    do
-    {
+    do {
         len = recvmsg(fd, msg, 0);
     } while (len < 0 && (errno == EINTR || errno == EAGAIN));
 
-    if (len <= 0)
-    {
+    if (len <= 0) {
         free(buf);
         ebpf_log("netlink recv error \n");
         rv = len;
         goto out;
     }
 
-    if (answer)
-    {
+    if (answer) {
         *answer = buf;
-    }
-    else
-    {
+    } else {
         free(buf);
     }
 
@@ -295,50 +249,38 @@ out:
     return rv;
 }
 
-static int
-rtnetlink_send(struct rtnetlink_handle *rtnl, 
-               struct nlmsghdr *nlmsg)
+static int rtnetlink_send(struct rtnetlink_handle *rtnl, struct nlmsghdr *nlmsg)
 {
-    struct iovec iov =
-    {
-        .iov_base = nlmsg,
-        .iov_len = nlmsg->nlmsg_len
-    };
+    struct iovec iov  = {.iov_base = nlmsg, .iov_len = nlmsg->nlmsg_len};
     struct iovec riov = {0};
 
-    struct sockaddr_nl nladdr =
-    {
-        .nl_family = AF_NETLINK
-    };
+    struct sockaddr_nl nladdr = {.nl_family = AF_NETLINK};
 
-    struct msghdr msg =
-    {
-        .msg_name = &nladdr,
+    struct msghdr msg = {
+        .msg_name    = &nladdr,
         .msg_namelen = sizeof(nladdr),
-        .msg_iov = &iov,
-        .msg_iovlen = 1,
+        .msg_iov     = &iov,
+        .msg_iovlen  = 1,
     };
 
-    unsigned int seq = 0;
+    unsigned int seq   = 0;
     struct nlmsghdr *h = NULL;
-    int recv_len = 0;
-    char *buf = NULL;
-    int rv = -1;
+    int recv_len       = 0;
+    char *buf          = NULL;
+    int rv             = -1;
 
-    if (!rtnl || !nlmsg)
-    {
+    if (!rtnl || !nlmsg) {
         ebpf_log("rtnetlink_send error: NULL parameter\n");
         rv = -1;
         goto out;
     }
 
-    h = iov.iov_base;
+    h            = iov.iov_base;
     h->nlmsg_seq = seq = ++rtnl->seq;
     /* request acknowledgement (NLMSG_ERROR packet) */
     h->nlmsg_flags |= NLM_F_ACK;
 
-    if (sendmsg(rtnl->fd, &msg, 0) < 0)
-    {
+    if (sendmsg(rtnl->fd, &msg, 0) < 0) {
         ebpf_log("failure talking to rtnetlink\n");
         rv = -1;
         goto out;
@@ -346,34 +288,28 @@ rtnetlink_send(struct rtnetlink_handle *rtnl,
 
     /* switch to response iov */
     memset(&riov, 0, sizeof(riov));
-    msg.msg_iov = &riov;
+    msg.msg_iov    = &riov;
     msg.msg_iovlen = 1;
 
     recv_len = rtnetlink_recv(rtnl->fd, &msg, &buf);
 
-    if (recv_len <= 0)
-    {
+    if (recv_len <= 0) {
         rv = -1;
         goto out;
     }
 
-    if (msg.msg_namelen != sizeof(nladdr))
-    {
-        ebpf_log("sender addr length == %d\n",
-            msg.msg_namelen);
+    if (msg.msg_namelen != sizeof(nladdr)) {
+        ebpf_log("sender addr length == %d\n", msg.msg_namelen);
         rv = -1;
         goto out;
     }
 
-    for (h = (struct nlmsghdr *)buf; recv_len >= sizeof(*h); )
-    {
+    for (h = (struct nlmsghdr *)buf; recv_len >= sizeof(*h);) {
         int len = h->nlmsg_len;
-        int l = len - sizeof(*h);
+        int l   = len - sizeof(*h);
 
-        if (l < 0 || len > recv_len)
-        {
-            if (msg.msg_flags & MSG_TRUNC)
-            {
+        if (l < 0 || len > recv_len) {
+            if (msg.msg_flags & MSG_TRUNC) {
                 ebpf_log("truncated message\n");
                 rv = -1;
                 goto out;
@@ -383,10 +319,8 @@ rtnetlink_send(struct rtnetlink_handle *rtnl,
             goto out;
         }
 
-        if (0 != nladdr.nl_pid ||
-            h->nlmsg_pid != rtnl->local.nl_pid ||
-            h->nlmsg_seq > seq || h->nlmsg_seq < seq - 1)
-        {
+        if (0 != nladdr.nl_pid || h->nlmsg_pid != rtnl->local.nl_pid ||
+            h->nlmsg_seq > seq || h->nlmsg_seq < seq - 1) {
             /* skip this message. */
             recv_len -= NLMSG_ALIGN(len);
             h = (struct nlmsghdr *)((char *)h + NLMSG_ALIGN(len));
@@ -394,20 +328,17 @@ rtnetlink_send(struct rtnetlink_handle *rtnl,
         }
 
         /* Parse acknowledgment packet */
-        if (h->nlmsg_type == NLMSG_ERROR)
-        {
+        if (h->nlmsg_type == NLMSG_ERROR) {
             struct nlmsgerr *err = (struct nlmsgerr *)NLMSG_DATA(h);
-            int error = err->error;
+            int error            = err->error;
 
-            if (l < sizeof(struct nlmsgerr))
-            {
+            if (l < sizeof(struct nlmsgerr)) {
                 ebpf_log("error truncated\n");
                 rv = -1;
                 goto out;
             }
 
-            if (error)
-            {
+            if (error) {
                 rtnetlink_send_error(err);
             }
 
@@ -421,73 +352,60 @@ rtnetlink_send(struct rtnetlink_handle *rtnl,
         h = (struct nlmsghdr *)((char *)h + NLMSG_ALIGN(len));
     }
 
-    if (msg.msg_flags & MSG_TRUNC)
-    {
+    if (msg.msg_flags & MSG_TRUNC) {
         ebpf_log("message truncated\n");
         rv = -1;
         goto out;
     }
 
-    if (recv_len)
-    {
+    if (recv_len) {
         ebpf_log("uneven reply, remained: %d\n", recv_len);
         rv = -1;
         goto out;
     }
 
 out:
-    if (buf)
-    {
+    if (buf) {
         free(buf);
     }
     return rv;
 }
 
-static int 
-netlink_qdisc(int cmd, 
-              unsigned int flags,
-              const char *ifname)
+static int netlink_qdisc(int cmd, unsigned int flags, const char *ifname)
 {
-    int rv = -1;
-    struct rtnetlink_handle qdisc_rth =
-    {
-        .fd = -1
-    };
-    struct netlink_msg qdisc_req = 
-    {
-        .n.nlmsg_len = NLMSG_LENGTH(sizeof(struct tcmsg)),
+    int rv                            = -1;
+    struct rtnetlink_handle qdisc_rth = {.fd = -1};
+    struct netlink_msg qdisc_req      = {
+        .n.nlmsg_len   = NLMSG_LENGTH(sizeof(struct tcmsg)),
         .n.nlmsg_flags = NLM_F_REQUEST | flags,
-        .n.nlmsg_type = cmd,
-        .t.tcm_family = AF_UNSPEC,
+        .n.nlmsg_type  = cmd,
+        .t.tcm_family  = AF_UNSPEC,
     };
 
-    if (!ifname)
-    {
+    if (!ifname) {
         ebpf_log("netlink_qdisc error: NULL parameter\n");
         rv = -1;
         goto out;
     }
 
-    if (rtnetlink_open(&qdisc_rth) < 0)
-    {
+    if (rtnetlink_open(&qdisc_rth) < 0) {
         ebpf_log("failed to open netlink\n");
         rv = -1;
         goto out;
     }
     qdisc_req.t.tcm_parent = TC_H_CLSACT;
     qdisc_req.t.tcm_handle = TC_H_MAKE(TC_H_CLSACT, 0);
-    attr_put(&qdisc_req.n, sizeof(qdisc_req), TCA_KIND, "clsact", strlen("clsact") + 1);
+    attr_put(&qdisc_req.n, sizeof(qdisc_req), TCA_KIND, "clsact",
+             strlen("clsact") + 1);
 
     qdisc_req.t.tcm_ifindex = if_nametoindex(ifname);
-    if (0 == qdisc_req.t.tcm_ifindex)
-    {
+    if (0 == qdisc_req.t.tcm_ifindex) {
         ebpf_log("failed to find device %s\n", ifname);
         rv = -1;
         goto out;
-    } 
+    }
     /* talk to netlink */
-    if (rtnetlink_send(&qdisc_rth, &qdisc_req.n) < 0)
-    {
+    if (rtnetlink_send(&qdisc_rth, &qdisc_req.n) < 0) {
         ebpf_log("error talking to the kernel (rtnetlink_send)\n");
         rv = -1;
         goto out;
@@ -499,28 +417,23 @@ out:
     return rv;
 }
 
-int 
-netlink_qdisc_add(const char *ifname)
+int netlink_qdisc_add(const char *ifname)
 {
     return netlink_qdisc(RTM_NEWQDISC, NLM_F_EXCL | NLM_F_CREATE, ifname);
 }
 
-int
-netlink_qdisc_del(const char *ifname)
+int netlink_qdisc_del(const char *ifname)
 {
     return netlink_qdisc(RTM_DELQDISC, 0, ifname);
 }
 
-int 
-netlink_filter_add_begin(struct netlink_ctx *ctx,
-                         const char *ifname)
+int netlink_filter_add_begin(struct netlink_ctx *ctx, const char *ifname)
 {
-    int rv = -1;
-    __u32 protocol = 0;
+    int rv             = -1;
+    __u32 protocol     = 0;
     struct nlmsghdr *n = NULL;
 
-    if (!ctx)
-    {
+    if (!ctx) {
         ebpf_log("netlink_filter_add_begin error: NULL parameter\n");
         rv = -1;
         goto out;
@@ -528,55 +441,51 @@ netlink_filter_add_begin(struct netlink_ctx *ctx,
 
     /* Initialize context for filter add */
     memset(ctx, 0, sizeof(*ctx));
-    ctx->filter_rth.fd = -1;
-    ctx->msg.n.nlmsg_len = NLMSG_LENGTH(sizeof(struct tcmsg));
+    ctx->filter_rth.fd     = -1;
+    ctx->msg.n.nlmsg_len   = NLMSG_LENGTH(sizeof(struct tcmsg));
     ctx->msg.n.nlmsg_flags = NLM_F_REQUEST | NLM_F_EXCL | NLM_F_CREATE;
-    ctx->msg.n.nlmsg_type = RTM_NEWTFILTER;
-    ctx->msg.t.tcm_family = AF_UNSPEC;
+    ctx->msg.n.nlmsg_type  = RTM_NEWTFILTER;
+    ctx->msg.t.tcm_family  = AF_UNSPEC;
 
-    if (rtnetlink_open(&ctx->filter_rth) < 0)
-    {
+    if (rtnetlink_open(&ctx->filter_rth) < 0) {
         ebpf_log("failed to open netlink\n");
         rtnetlink_close(&ctx->filter_rth);
         rv = -1;
         goto out;
     }
 
-    protocol = htons(ETH_P_ALL);
+    protocol              = htons(ETH_P_ALL);
     ctx->msg.t.tcm_parent = TC_H_MAKE(TC_H_CLSACT, TC_H_MIN_EGRESS);
-    ctx->msg.t.tcm_info = TC_H_MAKE(0 << 16, protocol);
+    ctx->msg.t.tcm_info   = TC_H_MAKE(0 << 16, protocol);
     attr_put(&ctx->msg.n, sizeof(ctx->msg), TCA_KIND, "bpf", strlen("bpf") + 1);
-    
+
     ctx->msg.t.tcm_ifindex = if_nametoindex(ifname);
-    if (0 == ctx->msg.t.tcm_ifindex)
-    {
+    if (0 == ctx->msg.t.tcm_ifindex) {
         ebpf_log("failed to find device %s\n", ifname);
         rtnetlink_close(&ctx->filter_rth);
         rv = -1;
         goto out;
-    } 
+    }
 
-    n = &ctx->msg.n;
+    n         = &ctx->msg.n;
     ctx->tail = (struct rtattr *)(((void *)n) + NLMSG_ALIGN(n->nlmsg_len));
     attr_put(n, MAX_MSG, TCA_OPTIONS, NULL, 0);
-    
+
     rv = 0;
 out:
     return rv;
 }
 
-int 
-netlink_filter_add_end(int fd,
-                       struct netlink_ctx *ctx,
-                       const char *ebpf_obj_filename)
+int netlink_filter_add_end(int fd,
+                           struct netlink_ctx *ctx,
+                           const char *ebpf_obj_filename)
 {
     struct nlmsghdr *nl = NULL;
     char buf[128];
-    int rv = -1;
+    int rv  = -1;
     int len = 0;
 
-    if (!ctx || !ebpf_obj_filename)
-    {
+    if (!ctx || !ebpf_obj_filename) {
         ebpf_log("netlink_filter_add_end error: NULL parameter\n");
         rv = -1;
         goto out;
@@ -586,8 +495,7 @@ netlink_filter_add_end(int fd,
     memset(buf, 0, sizeof(buf));
 
     len = snprintf(buf, sizeof(buf), "%s:[.text]", ebpf_obj_filename);
-    if (len < 0 || len >= sizeof(buf))
-    {
+    if (len < 0 || len >= sizeof(buf)) {
         ebpf_log("netlink_filter_add_end error: filename too long\n");
         rv = -1;
         goto out;
@@ -595,12 +503,11 @@ netlink_filter_add_end(int fd,
 
     attr_put_32(nl, MAX_MSG, TCA_BPF_FD, fd);
     attr_put_str(nl, MAX_MSG, TCA_BPF_NAME, buf);
-    attr_put_32(nl, MAX_MSG, TCA_BPF_FLAGS, TCA_BPF_FLAG_ACT_DIRECT);   
+    attr_put_32(nl, MAX_MSG, TCA_BPF_FLAGS, TCA_BPF_FLAG_ACT_DIRECT);
     ctx->tail->rta_len = (((void *)nl) + nl->nlmsg_len) - (void *)ctx->tail;
 
     /* talk to netlink */
-    if (rtnetlink_send(&ctx->filter_rth, &ctx->msg.n) < 0)
-    {
+    if (rtnetlink_send(&ctx->filter_rth, &ctx->msg.n) < 0) {
         ebpf_log("error talking to the kernel (rtnetlink_send)\n");
         rv = -1;
         goto out;
@@ -608,8 +515,7 @@ netlink_filter_add_end(int fd,
 
     rv = 0;
 out:
-    if (ctx)
-    {
+    if (ctx) {
         rtnetlink_close(&ctx->filter_rth);
     }
     return rv;

--- a/non-GPL/TcLoader/TcLoader.c
+++ b/non-GPL/TcLoader/TcLoader.c
@@ -416,7 +416,10 @@ int netlink_qdisc_add(const char *ifname)
     return netlink_qdisc(RTM_NEWQDISC, NLM_F_EXCL | NLM_F_CREATE, ifname);
 }
 
-int netlink_qdisc_del(const char *ifname) { return netlink_qdisc(RTM_DELQDISC, 0, ifname); }
+int netlink_qdisc_del(const char *ifname)
+{
+    return netlink_qdisc(RTM_DELQDISC, 0, ifname);
+}
 
 int netlink_filter_add_begin(struct netlink_ctx *ctx, const char *ifname)
 {

--- a/non-GPL/TcLoader/TcLoader.c
+++ b/non-GPL/TcLoader/TcLoader.c
@@ -55,11 +55,9 @@ enum {
     __TCA_BPF_MAX,
 };
 
-#define NLMSG_TAIL(nmsg)                                                       \
-    ((struct rtattr *)(((void *)(nmsg)) + NLMSG_ALIGN((nmsg)->nlmsg_len)))
+#define NLMSG_TAIL(nmsg) ((struct rtattr *)(((void *)(nmsg)) + NLMSG_ALIGN((nmsg)->nlmsg_len)))
 
-static int
-attr_put(struct nlmsghdr *n, int max, int type, const void *buf, int attr_len)
+static int attr_put(struct nlmsghdr *n, int max, int type, const void *buf, int attr_len)
 {
     int len            = RTA_LENGTH(attr_len);
     struct rtattr *rta = NULL;
@@ -132,15 +130,13 @@ static int rtnetlink_open(struct rtnetlink_handle *rth)
         goto out;
     }
 
-    if (setsockopt(rth->fd, SOL_SOCKET, SO_SNDBUF, &sendbuf, sizeof(sendbuf)) <
-        0) {
+    if (setsockopt(rth->fd, SOL_SOCKET, SO_SNDBUF, &sendbuf, sizeof(sendbuf)) < 0) {
         ebpf_log("error setsockopt sendbuf\n");
         rv = -1;
         goto out;
     }
 
-    if (setsockopt(rth->fd, SOL_SOCKET, SO_RCVBUF, &receivebuf,
-                   sizeof(receivebuf)) < 0) {
+    if (setsockopt(rth->fd, SOL_SOCKET, SO_RCVBUF, &receivebuf, sizeof(receivebuf)) < 0) {
         ebpf_log("error setsockopt receivebuf\n");
         rv = -1;
         goto out;
@@ -163,8 +159,7 @@ static int rtnetlink_open(struct rtnetlink_handle *rth)
         goto out;
     }
     address_len = sizeof(rth->local);
-    if (getsockname(rth->fd, (struct sockaddr *)&rth->local, &address_len) <
-        0) {
+    if (getsockname(rth->fd, (struct sockaddr *)&rth->local, &address_len) < 0) {
         ebpf_log("error getsockname\n");
         rv = -1;
         goto out;
@@ -319,8 +314,8 @@ static int rtnetlink_send(struct rtnetlink_handle *rtnl, struct nlmsghdr *nlmsg)
             goto out;
         }
 
-        if (0 != nladdr.nl_pid || h->nlmsg_pid != rtnl->local.nl_pid ||
-            h->nlmsg_seq > seq || h->nlmsg_seq < seq - 1) {
+        if (0 != nladdr.nl_pid || h->nlmsg_pid != rtnl->local.nl_pid || h->nlmsg_seq > seq ||
+            h->nlmsg_seq < seq - 1) {
             /* skip this message. */
             recv_len -= NLMSG_ALIGN(len);
             h = (struct nlmsghdr *)((char *)h + NLMSG_ALIGN(len));
@@ -395,8 +390,7 @@ static int netlink_qdisc(int cmd, unsigned int flags, const char *ifname)
     }
     qdisc_req.t.tcm_parent = TC_H_CLSACT;
     qdisc_req.t.tcm_handle = TC_H_MAKE(TC_H_CLSACT, 0);
-    attr_put(&qdisc_req.n, sizeof(qdisc_req), TCA_KIND, "clsact",
-             strlen("clsact") + 1);
+    attr_put(&qdisc_req.n, sizeof(qdisc_req), TCA_KIND, "clsact", strlen("clsact") + 1);
 
     qdisc_req.t.tcm_ifindex = if_nametoindex(ifname);
     if (0 == qdisc_req.t.tcm_ifindex) {
@@ -422,10 +416,7 @@ int netlink_qdisc_add(const char *ifname)
     return netlink_qdisc(RTM_NEWQDISC, NLM_F_EXCL | NLM_F_CREATE, ifname);
 }
 
-int netlink_qdisc_del(const char *ifname)
-{
-    return netlink_qdisc(RTM_DELQDISC, 0, ifname);
-}
+int netlink_qdisc_del(const char *ifname) { return netlink_qdisc(RTM_DELQDISC, 0, ifname); }
 
 int netlink_filter_add_begin(struct netlink_ctx *ctx, const char *ifname)
 {
@@ -476,9 +467,7 @@ out:
     return rv;
 }
 
-int netlink_filter_add_end(int fd,
-                           struct netlink_ctx *ctx,
-                           const char *ebpf_obj_filename)
+int netlink_filter_add_end(int fd, struct netlink_ctx *ctx, const char *ebpf_obj_filename)
 {
     struct nlmsghdr *nl = NULL;
     char buf[128];

--- a/non-GPL/TcLoader/TcLoader.h
+++ b/non-GPL/TcLoader/TcLoader.h
@@ -80,7 +80,5 @@ int netlink_filter_add_begin(struct netlink_ctx *ctx, const char *ifname);
  * @param[in] ebpf_obj_filename eBPF object filename
  * @return Error value (0 for success)
  */
-int netlink_filter_add_end(int fd,
-                           struct netlink_ctx *ctx,
-                           const char *ebpf_obj_filename);
+int netlink_filter_add_end(int fd, struct netlink_ctx *ctx, const char *ebpf_obj_filename);
 #endif

--- a/non-GPL/TcLoader/TcLoader.h
+++ b/non-GPL/TcLoader/TcLoader.h
@@ -14,6 +14,7 @@
 #include <linux/rtnetlink.h>
 #include <net/if.h>
 #include <netinet/in.h>
+#include <stdio.h>
 
 /* maximum netlink message size */
 #define MAX_MSG 16384

--- a/non-GPL/TcLoader/TcLoader.h
+++ b/non-GPL/TcLoader/TcLoader.h
@@ -1,9 +1,10 @@
 // SPDX-License-Identifier: LicenseRef-Elastic-License-2.0
 
 /*
- * Copyright 2021 Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the Elastic License 2.0;
- * you may not use this file except in compliance with the Elastic License 2.0.
+ * Copyright 2021 Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under
+ * one or more contributor license agreements. Licensed under the Elastic
+ * License 2.0; you may not use this file except in compliance with the Elastic
+ * License 2.0.
  */
 
 #ifndef EBPF_TCLOADER_H
@@ -17,31 +18,30 @@
 /* maximum netlink message size */
 #define MAX_MSG 16384
 
-struct rtnetlink_handle
-{
-    int                 fd;
-    struct sockaddr_nl  local;
-    struct sockaddr_nl  peer;
-    __u32               seq;
-    __u32               dump;
-    int                 proto;
-    FILE               *dump_fp;
-#define RTNL_HANDLE_F_LISTEN_ALL_NSID       0x01
-#define RTNL_HANDLE_F_SUPPRESS_NLERR        0x02
-#define RTNL_HANDLE_F_STRICT_CHK        0x04
-    int                 flags;
+struct rtnetlink_handle {
+    int fd;
+    struct sockaddr_nl local;
+    struct sockaddr_nl peer;
+    __u32 seq;
+    __u32 dump;
+    int proto;
+    FILE *dump_fp;
+#define RTNL_HANDLE_F_LISTEN_ALL_NSID 0x01
+#define RTNL_HANDLE_F_SUPPRESS_NLERR 0x02
+#define RTNL_HANDLE_F_STRICT_CHK 0x04
+    int flags;
 };
 
 struct netlink_msg {
     struct nlmsghdr n;
-    struct tcmsg    t;
-    char            buf[MAX_MSG];
+    struct tcmsg t;
+    char buf[MAX_MSG];
 };
 
 struct netlink_ctx {
-    struct rtattr           *tail;
+    struct rtattr *tail;
     struct rtnetlink_handle filter_rth;
-    struct netlink_msg      msg;
+    struct netlink_msg msg;
 };
 
 /**
@@ -50,8 +50,7 @@ struct netlink_ctx {
  * @param[in] ifname Network interface name
  * @return Error value (0 for success)
  */
-int 
-netlink_qdisc_add(const char *ifname);
+int netlink_qdisc_add(const char *ifname);
 
 /**
  * @brief Remove qdisc from a network interface
@@ -59,30 +58,28 @@ netlink_qdisc_add(const char *ifname);
  * @param[in] ifname Network interface name
  * @return Error value (0 for success)
  */
-int
-netlink_qdisc_del(const char *ifname);
+int netlink_qdisc_del(const char *ifname);
 
 /**
  * @brief Add eBPF tc filter to a network interface (initialize only)
  *
- * @param[in] ctx Context containing netlink state - allocated and passed by caller
+ * @param[in] ctx Context containing netlink state - allocated and passed by
+ * caller
  * @param[in] ifname Network interface name
  * @return Error value (0 for success)
  */
-int 
-netlink_filter_add_begin(struct netlink_ctx *ctx,
-                         const char *ifname);
+int netlink_filter_add_begin(struct netlink_ctx *ctx, const char *ifname);
 
 /**
  * @brief Add eBPF tc filter to a network interface (commit)
  *
  * @param[in] fd eBPF program file descriptor
- * @param[in] ctx Context containing netlink state (from previous add_begin() call) - passed by caller
+ * @param[in] ctx Context containing netlink state (from previous add_begin()
+ * call) - passed by caller
  * @param[in] ebpf_obj_filename eBPF object filename
  * @return Error value (0 for success)
  */
-int 
-netlink_filter_add_end(int fd,
-                       struct netlink_ctx *ctx,
-                       const char *ebpf_obj_filename);
+int netlink_filter_add_end(int fd,
+                           struct netlink_ctx *ctx,
+                           const char *ebpf_obj_filename);
 #endif

--- a/non-GPL/TcLoader/TcLoaderDemo.c
+++ b/non-GPL/TcLoader/TcLoaderDemo.c
@@ -148,8 +148,7 @@ int main(int argc, char **argv)
     obj = NULL;
 
     /* tc filter add continued */
-    if (netlink_filter_add_end(prog_fd_dupd, &nl_ctx, EBPF_OBJ_FILE_NAME) !=
-        0) {
+    if (netlink_filter_add_end(prog_fd_dupd, &nl_ctx, EBPF_OBJ_FILE_NAME) != 0) {
         fprintf(stderr, "filter_add_end() failed\n");
         close(prog_fd_dupd);
         rv = -1;

--- a/non-GPL/TcLoader/TcLoaderDemo.c
+++ b/non-GPL/TcLoader/TcLoaderDemo.c
@@ -1,78 +1,67 @@
 // SPDX-License-Identifier: LicenseRef-Elastic-License-2.0
 
 /*
- * Copyright 2021 Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the Elastic License 2.0;
- * you may not use this file except in compliance with the Elastic License 2.0.
+ * Copyright 2021 Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under
+ * one or more contributor license agreements. Licensed under the Elastic
+ * License 2.0; you may not use this file except in compliance with the Elastic
+ * License 2.0.
  */
-
 
 //
 // Host Isolation standalone demo
 // Loader for eBPF program #1 (replacement for 'tc filter add')
-// 
-#include <stdio.h>
-#include <stdlib.h>
+//
+#include <Common.h>
 #include <argp.h>
-#include <unistd.h>
-#include <fcntl.h>
-#include <string.h>
-
-#include <linux/netlink.h>
-#include <linux/rtnetlink.h>
-
-#include <net/if.h>
-#include <netinet/in.h>
-#include <sys/socket.h>
-#include <sys/stat.h>
-
 #include <bpf/bpf.h>
 #include <bpf/libbpf.h>
+#include <fcntl.h>
+#include <linux/netlink.h>
+#include <linux/rtnetlink.h>
+#include <net/if.h>
+#include <netinet/in.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <sys/stat.h>
+#include <unistd.h>
 
-#include <Common.h>
 #include "TcLoader.h"
 
 /* UPDATE ACCORDINGLY */
 #define IFNAME_TO_ATTACH_TO "ens33"
 #define EBPF_OBJ_FILE_NAME "TcFilter.bpf.o"
 
-int 
-main(int argc, 
-     char **argv)
+int main(int argc, char **argv)
 {
     struct netlink_ctx nl_ctx;
     struct bpf_program *prog = NULL;
-    struct bpf_program *p = NULL;
-    struct bpf_object *obj = NULL;
-    struct bpf_map *map = NULL;
-    const char *map_name = NULL;
-    char buf[256] = {0};
-    int prog_fd_dupd = 0;
-    int rv = -1;
-
+    struct bpf_program *p    = NULL;
+    struct bpf_object *obj   = NULL;
+    struct bpf_map *map      = NULL;
+    const char *map_name     = NULL;
+    char buf[256]            = {0};
+    int prog_fd_dupd         = 0;
+    int rv                   = -1;
 
     memset(&nl_ctx, 0, sizeof(nl_ctx));
 
     /* do the same things as 'tc qdisc del dev <iface> clsact' */
-    if (netlink_qdisc_del(IFNAME_TO_ATTACH_TO) != 0)
-    {
+    if (netlink_qdisc_del(IFNAME_TO_ATTACH_TO) != 0) {
         fprintf(stderr, "failed to del qdisc\n");
-    }
-    else
-    {
+    } else {
         printf("DELETED QDISC\n");
     }
 
     /* if 'unload' is passed as arg, only delete qdisc */
-    if ((argc > 1) && !strcmp(argv[1], "unload"))
-    {
+    if ((argc > 1) && !strcmp(argv[1], "unload")) {
         rv = 0;
         goto out;
     }
 
     /* 'tc qdisc add dev <iface> clsact' */
-    if (netlink_qdisc_add(IFNAME_TO_ATTACH_TO) != 0)
-    {
+    if (netlink_qdisc_add(IFNAME_TO_ATTACH_TO) != 0) {
         fprintf(stderr, "failed to add qdisc\n");
         rv = -1;
         goto out;
@@ -82,23 +71,20 @@ main(int argc,
 
     /* 'tc filter add dev <iface> egress bpf da obj <ebpf_file> sec .text' */
     /* finished when netlink_filter_add_end() is called */
-    if (netlink_filter_add_begin(&nl_ctx, IFNAME_TO_ATTACH_TO) != 0)
-    {
+    if (netlink_filter_add_begin(&nl_ctx, IFNAME_TO_ATTACH_TO) != 0) {
         fprintf(stderr, "filter_add_begin() failed\n");
         rv = -1;
         goto out;
     }
 
     /* create elastic/endpoint dir in bpf fs */
-    if (mkdir(EBPF_MAP_PARENT_DIRECTORY, 0700) && errno != EEXIST)
-    {
+    if (mkdir(EBPF_MAP_PARENT_DIRECTORY, 0700) && errno != EEXIST) {
         perror("failed to create directory: " EBPF_MAP_PARENT_DIRECTORY);
         rv = -1;
         goto out;
     }
 
-    if (mkdir(EBPF_MAP_DIRECTORY, 0700) && errno != EEXIST)
-    {
+    if (mkdir(EBPF_MAP_DIRECTORY, 0700) && errno != EEXIST) {
         perror("failed to create directory: " EBPF_MAP_DIRECTORY);
         rv = -1;
         goto out;
@@ -106,14 +92,11 @@ main(int argc,
 
     ebpf_set_log_func(ebpf_default_log_func());
 
-    DECLARE_LIBBPF_OPTS(bpf_object_open_opts, open_opts,
-        .relaxed_maps = true,
-        .pin_root_path = EBPF_MAP_DIRECTORY,
-    );
+    DECLARE_LIBBPF_OPTS(bpf_object_open_opts, open_opts, .relaxed_maps = true,
+                        .pin_root_path = EBPF_MAP_DIRECTORY, );
 
     obj = bpf_object__open_file(EBPF_OBJ_FILE_NAME, &open_opts);
-    if (!obj || libbpf_get_error(obj))
-    {
+    if (!obj || libbpf_get_error(obj)) {
         fprintf(stderr, "failed to open BPF object\n");
         bpf_object__close(obj);
         rv = -1;
@@ -125,8 +108,7 @@ main(int argc,
     {
         bpf_program__set_type(p, BPF_PROG_TYPE_SCHED_CLS);
         bpf_program__set_ifindex(p, 0); //?
-        if (!prog)
-        {
+        if (!prog) {
             prog = p;
         }
     }
@@ -134,19 +116,19 @@ main(int argc,
     {
         bpf_map__set_ifindex(map, 0); //?
         map_name = bpf_map__name(map);
-        if (map_name)
-        {
-            rv = snprintf(buf, sizeof(buf), EBPF_MAP_DIRECTORY "/" "%s", map_name);
-            if (rv > 0)
-            {
+        if (map_name) {
+            rv = snprintf(buf, sizeof(buf),
+                          EBPF_MAP_DIRECTORY "/"
+                                             "%s",
+                          map_name);
+            if (rv > 0) {
                 bpf_map__set_pin_path(map, buf);
             }
         }
     }
 
     rv = bpf_object__load(obj);
-    if (rv)
-    {
+    if (rv) {
         fprintf(stderr, "failed to load BPF program\n");
         bpf_object__close(obj);
         rv = -1;
@@ -155,20 +137,19 @@ main(int argc,
     printf("BPF PROG LOADED\n");
 
     prog_fd_dupd = fcntl(bpf_program__fd(prog), F_DUPFD_CLOEXEC, 1);
-    if (prog_fd_dupd < 0)
-    {
+    if (prog_fd_dupd < 0) {
         perror("bad prog_fd_dupd");
         bpf_object__close(obj);
         rv = -1;
         goto out;
     }
-    
+
     bpf_object__close(obj);
     obj = NULL;
 
     /* tc filter add continued */
-    if (netlink_filter_add_end(prog_fd_dupd, &nl_ctx, EBPF_OBJ_FILE_NAME) != 0)
-    {
+    if (netlink_filter_add_end(prog_fd_dupd, &nl_ctx, EBPF_OBJ_FILE_NAME) !=
+        0) {
         fprintf(stderr, "filter_add_end() failed\n");
         close(prog_fd_dupd);
         rv = -1;


### PR DESCRIPTION
This PR adds a `.clang-format`, formats the code, and updates the `Jenkinsfile` to error if code isn't formatted.

It's branched off #51 as it's not yet merged. Opening it up now to get reviews early.

Code can now be formatted as follows:

```bash
find GPL/ non-GPL/ -name "*.[c,h]" | xargs clang-format -i
```

Here's the `.clang-format` I added:

```yaml
BasedOnStyle: LLVM
IndentWidth: 4
BreakBeforeBraces: Linux
BinPackParameters: false
AlignConsecutiveAssignments: true
```

See all possible values that can go into a `.clang-format` [here](https://clang.llvm.org/docs/ClangFormatStyleOptions.html).

I'll give a small bit of rationale here for why I chose these values, but want to emphasize that I ultimately don't really care about the minutia of the code style, I just care that we have one and that it's applied consistently and enforced by Jenkins. The lack of consistent code formatting in this repo was really getting to me. This is code style, so all of the choices I've made are by definition subjective and up to the whims of personal preference (especially the last three). I'm not married to this `.clang-format`, happy to change it if everyone else is against me, I really just want consistent formatting.

Rationale for `.clang-format` values:

```yaml
BasedOnStyle: LLVM
```
Might as well choose something widely used for the base style. LLVM style isn't that esoteric (like GNU for example) and is pretty widely used.

```yaml
IndentWidth: 4
```
LLVM style specifies this as 2, but absolutely everyone here was using 4 already, so seems like we have consensus on that.

```yaml
BreakBeforeBraces: Linux
```
Uses the Linux brace breaking style, so function definitions have their opening `{` on a new line, but `if`/`while`/`for` keep it on the same line. IMO we should try to emulate kernel code style here since this is more-or-less kernel code. This is highly subjective however, happy to drop it if there are objections.

```yaml
BinPackParameters: false
```
Ensures that function prototypes all have their arguments on the same line, or, if they don't fit, each one will have one line each. e.g.

```c
true:
void f(int aaaaaaaaaaaaaaaaaaaa, int aaaaaaaaaaaaaaaaaaaa,
       int aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa) {}

false:
void f(int aaaaaaaaaaaaaaaaaaaa,
       int aaaaaaaaaaaaaaaaaaaa,
       int aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa) {}
```

IMO this is really nice for BPF probe definitions (which we will have a lot of), e.g.

```c
true:
int BPF_PROG(security_path_unlink_exit, const struct path *dir, 
                         struct dentry *dentry, long ret)

false:
int BPF_PROG(security_path_unlink_exit,
             const struct path *dir,
             struct dentry *dentry,
             long ret)
```

```yaml
AlignConsecutiveAssignments: true
```
Without this, enum definitions where each item has a specific value (which I anticipate a fair bit of), look wonky e.g.

```c
enum ebpf_event_type {
    EBPF_EVENT_PROCESS_FORK = (1 << 1),
    EBPF_EVENT_PROCESS_EXEC = (1 << 2),
    EBPF_EVENT_FILE_DELETE = (1 << 3),
};
```
vs:
```c
enum ebpf_event_type {
    EBPF_EVENT_PROCESS_FORK = (1 << 1),
    EBPF_EVENT_PROCESS_EXEC = (1 << 2),
    EBPF_EVENT_FILE_DELETE  = (1 << 3),
};
```

I'm also of the opinion that it enhances readability generally. It's also used in other C/C++ projects at Elastic.

Fixes #42 