### PR TITLE
Implement event filtering

### DIFF
--- a/cmake/modules/BPF.cmake
+++ b/cmake/modules/BPF.cmake
@@ -11,7 +11,7 @@ set(CLANG "clang")
 set(LLC "llc")
 set(BPFTOOL "bpftool")
 set(BTF_FILE "/sys/kernel/btf/vmlinux")
-option(USE_BUILTIN_VMLINUX "Wether or not to use the builtin vmlinux.h for building the BPF programs instead of trying to generate one from the system" False)
+option(USE_BUILTIN_VMLINUX "Whether or not to use the builtin vmlinux.h for building the BPF programs instead of trying to generate one from the system" False)
 
 # Standard includes
 execute_process(COMMAND ${CLANG} -print-file-name=include

--- a/non-GPL/EventsTrace/EventsTrace.c
+++ b/non-GPL/EventsTrace/EventsTrace.c
@@ -34,6 +34,10 @@ static const struct argp_option opts[] = {
      "Whether or not to consider process fork events"},
     {"process-exec", EBPF_EVENT_PROCESS_EXEC, NULL, false,
      "Whether or not to consider process exec events"},
+    {"process-exit", EBPF_EVENT_PROCESS_EXIT, NULL, false,
+     "Whether or not to consider process exit events"},
+    {"process-setsid", EBPF_EVENT_PROCESS_SETSID, NULL, false,
+     "Whether or not to consider process setsid events"},
     {},
 };
 
@@ -42,16 +46,14 @@ static error_t parse_arg(int key, char *arg, struct argp_state *state)
 {
     switch (key) {
     case 'a':
-        g_events_env = EBPF_EVENT_FILE_DELETE | EBPF_EVENT_PROCESS_FORK | EBPF_EVENT_PROCESS_EXEC;
+        g_events_env = UINT64_MAX;
         break;
     case EBPF_EVENT_FILE_DELETE:
-        g_events_env |= EBPF_EVENT_FILE_DELETE;
-        break;
     case EBPF_EVENT_PROCESS_FORK:
-        g_events_env |= EBPF_EVENT_PROCESS_FORK;
-        break;
     case EBPF_EVENT_PROCESS_EXEC:
-        g_events_env |= EBPF_EVENT_PROCESS_EXEC;
+    case EBPF_EVENT_PROCESS_EXIT:
+    case EBPF_EVENT_PROCESS_SETSID:
+        g_events_env |= key;
         break;
     case ARGP_KEY_ARG:
         argp_usage(state);

--- a/non-GPL/EventsTrace/EventsTrace.c
+++ b/non-GPL/EventsTrace/EventsTrace.c
@@ -314,8 +314,7 @@ static int event_ctx_callback(struct ebpf_event_header *evt_hdr)
 
 int main(int argc, char **argv)
 {
-    int err                      = 0;
-    struct FileEvents_bpf *probe = NULL;
+    int err = 0;
 
     if (signal(SIGINT, sig_int) == SIG_ERR) {
         fprintf(stderr, "Failed to register SIGINT handler\n");
@@ -344,8 +343,6 @@ int main(int argc, char **argv)
     }
 
 cleanup:
-    if (probe) {
-        ebpf_event_ctx__destroy(ctx);
-    }
+    ebpf_event_ctx__destroy(ctx);
     return err != 0;
 }

--- a/non-GPL/EventsTrace/EventsTrace.c
+++ b/non-GPL/EventsTrace/EventsTrace.c
@@ -27,13 +27,13 @@ const char argp_program_doc[] =
     "USAGE: ./EventsTrace [--all] [--file-delete] [--process-fork] [--process-exec]\n";
 
 static const struct argp_option opts[] = {
-    {"all", 'a', NULL, false, "Wether or not to consider all the events"},
+    {"all", 'a', NULL, false, "Whether or not to consider all the events"},
     {"file-delete", EBPF_EVENT_FILE_DELETE, NULL, false,
-     "Wether or not to consider file delete events"},
+     "Whether or not to consider file delete events"},
     {"process-fork", EBPF_EVENT_PROCESS_FORK, NULL, false,
-     "Wether or not to consider process fork events"},
+     "Whether or not to consider process fork events"},
     {"process-exec", EBPF_EVENT_PROCESS_EXEC, NULL, false,
-     "Wether or not to consider process exec events"},
+     "Whether or not to consider process exec events"},
     {},
 };
 

--- a/non-GPL/EventsTrace/EventsTrace.c
+++ b/non-GPL/EventsTrace/EventsTrace.c
@@ -318,6 +318,7 @@ static int event_ctx_callback(struct ebpf_event_header *evt_hdr)
 int main(int argc, char **argv)
 {
     int err = 0;
+    struct ebpf_event_ctx *ctx;
 
     if (signal(SIGINT, sig_int) == SIG_ERR) {
         fprintf(stderr, "Failed to register SIGINT handler\n");
@@ -328,7 +329,6 @@ int main(int argc, char **argv)
     if (err)
         goto cleanup;
 
-    struct ebpf_event_ctx *ctx;
     uint64_t features = EBPF_KERNEL_FEATURE_BPF;
     uint64_t events   = g_events_env;
     err               = ebpf_event_ctx__new(&ctx, event_ctx_callback, features, events);

--- a/non-GPL/EventsTrace/EventsTrace.c
+++ b/non-GPL/EventsTrace/EventsTrace.c
@@ -318,7 +318,7 @@ static int event_ctx_callback(struct ebpf_event_header *evt_hdr)
 int main(int argc, char **argv)
 {
     int err = 0;
-    struct ebpf_event_ctx *ctx;
+    struct ebpf_event_ctx *ctx = NULL;
 
     if (signal(SIGINT, sig_int) == SIG_ERR) {
         fprintf(stderr, "Failed to register SIGINT handler\n");

--- a/non-GPL/EventsTrace/EventsTrace.c
+++ b/non-GPL/EventsTrace/EventsTrace.c
@@ -317,7 +317,7 @@ static int event_ctx_callback(struct ebpf_event_header *evt_hdr)
 
 int main(int argc, char **argv)
 {
-    int err = 0;
+    int err                    = 0;
     struct ebpf_event_ctx *ctx = NULL;
 
     if (signal(SIGINT, sig_int) == SIG_ERR) {
@@ -346,6 +346,6 @@ int main(int argc, char **argv)
     }
 
 cleanup:
-    ebpf_event_ctx__destroy(ctx);
+    ebpf_event_ctx__destroy(&ctx);
     return err != 0;
 }

--- a/non-GPL/EventsTrace/EventsTrace.c
+++ b/non-GPL/EventsTrace/EventsTrace.c
@@ -41,7 +41,8 @@ static const struct argp_option opts[] = {
     {},
 };
 
-uint64_t g_events_env;
+uint64_t g_events_env = 0;
+
 static error_t parse_arg(int key, char *arg, struct argp_state *state)
 {
     switch (key) {

--- a/non-GPL/EventsTrace/EventsTrace.c
+++ b/non-GPL/EventsTrace/EventsTrace.c
@@ -37,21 +37,21 @@ static const struct argp_option opts[] = {
     {},
 };
 
-uint64_t events_env;
+uint64_t g_events_env;
 static error_t parse_arg(int key, char *arg, struct argp_state *state)
 {
     switch (key) {
     case 'a':
-        events_env = EBPF_EVENT_FILE_DELETE | EBPF_EVENT_PROCESS_FORK | EBPF_EVENT_PROCESS_EXEC;
+        g_events_env = EBPF_EVENT_FILE_DELETE | EBPF_EVENT_PROCESS_FORK | EBPF_EVENT_PROCESS_EXEC;
         break;
     case EBPF_EVENT_FILE_DELETE:
-        events_env |= EBPF_EVENT_FILE_DELETE;
+        g_events_env |= EBPF_EVENT_FILE_DELETE;
         break;
     case EBPF_EVENT_PROCESS_FORK:
-        events_env |= EBPF_EVENT_PROCESS_FORK;
+        g_events_env |= EBPF_EVENT_PROCESS_FORK;
         break;
     case EBPF_EVENT_PROCESS_EXEC:
-        events_env |= EBPF_EVENT_PROCESS_EXEC;
+        g_events_env |= EBPF_EVENT_PROCESS_EXEC;
         break;
     case ARGP_KEY_ARG:
         argp_usage(state);
@@ -324,11 +324,11 @@ int main(int argc, char **argv)
 
     err = argp_parse(&argp, argc, argv, 0, NULL, NULL);
     if (err)
-        return err;
+        goto cleanup;
 
     struct ebpf_event_ctx *ctx;
     uint64_t features = EBPF_KERNEL_FEATURE_BPF;
-    uint64_t events   = events_env;
+    uint64_t events   = g_events_env;
     err               = ebpf_event_ctx__new(&ctx, event_ctx_callback, features, events);
     if (err < 0) {
         fprintf(stderr, "Could not create event context: %d %s\n", err, strerror(-err));

--- a/non-GPL/LibEbpfEvents/LibEbpfEvents.c
+++ b/non-GPL/LibEbpfEvents/LibEbpfEvents.c
@@ -108,6 +108,9 @@ int ebpf_event_ctx__next(struct ebpf_event_ctx *ctx, int timeout)
 
 void ebpf_event_ctx__destroy(struct ebpf_event_ctx *ctx)
 {
+    if (!ctx) {
+        return;
+    }
     if (ctx->ringbuf) {
         ring_buffer__free(ctx->ringbuf);
     }
@@ -118,8 +121,7 @@ void ebpf_event_ctx__destroy(struct ebpf_event_ctx *ctx)
         free(ctx->cb_ctx);
         ctx->cb_ctx = NULL;
     }
-    if (ctx) {
-        free(ctx);
-        ctx = NULL;
-    }
+
+    free(ctx);
+    ctx = NULL;
 }

--- a/non-GPL/LibEbpfEvents/LibEbpfEvents.c
+++ b/non-GPL/LibEbpfEvents/LibEbpfEvents.c
@@ -18,7 +18,7 @@
 
 struct ring_buf_cb_ctx {
     ebpf_event_handler_fn cb;
-    uint64_t events;
+    uint64_t events_mask;
 };
 struct ebpf_event_ctx {
     struct ring_buffer *ringbuf;
@@ -32,7 +32,7 @@ static int ring_buf_cb(void *ctx, void *data, size_t size)
     struct ring_buf_cb_ctx *cb_ctx = ctx;
     ebpf_event_handler_fn cb       = cb_ctx->cb;
     struct ebpf_event_header *evt  = data;
-    if (evt->type & cb_ctx->events) {
+    if (evt->type & cb_ctx->events_mask) {
         return cb(evt);
     }
     return 0;
@@ -79,7 +79,7 @@ int ebpf_event_ctx__new(struct ebpf_event_ctx **ctx,
 
 
     (*ctx)->cb_ctx->cb     = cb;
-    (*ctx)->cb_ctx->events = events;
+    (*ctx)->cb_ctx->events_mask = events;
 
     (*ctx)->ringbuf =
         ring_buffer__new(bpf_map__fd((*ctx)->probe->maps.ringbuf), ring_buf_cb, (*ctx)->cb_ctx, &opts);

--- a/non-GPL/LibEbpfEvents/LibEbpfEvents.c
+++ b/non-GPL/LibEbpfEvents/LibEbpfEvents.c
@@ -47,7 +47,7 @@ int ebpf_event_ctx__new(struct ebpf_event_ctx **ctx,
 
     int err;
     *ctx = calloc(1, sizeof(struct ebpf_event_ctx));
-    if (ctx == NULL)
+    if (*ctx == NULL)
         return -ENOMEM;
 
     (*ctx)->probe = EventProbe_bpf__open();

--- a/non-GPL/LibEbpfEvents/LibEbpfEvents.c
+++ b/non-GPL/LibEbpfEvents/LibEbpfEvents.c
@@ -71,19 +71,18 @@ int ebpf_event_ctx__new(struct ebpf_event_ctx **ctx,
     struct ring_buffer_opts opts;
     opts.sz = sizeof(opts);
 
-    struct ring_buf_cb_ctx *cb_ctx = (*ctx)->cb_ctx;
-
-    cb_ctx = calloc(1, sizeof(struct ring_buf_cb_ctx));
-    if (cb_ctx == NULL) {
+    (*ctx)->cb_ctx = calloc(1, sizeof(struct ring_buf_cb_ctx));
+    if ((*ctx)->cb_ctx == NULL) {
         err = -ENOMEM;
         goto out_destroy_probe;
     }
 
-    cb_ctx->cb     = cb;
-    cb_ctx->events = events;
+
+    (*ctx)->cb_ctx->cb     = cb;
+    (*ctx)->cb_ctx->events = events;
 
     (*ctx)->ringbuf =
-        ring_buffer__new(bpf_map__fd((*ctx)->probe->maps.ringbuf), ring_buf_cb, cb_ctx, &opts);
+        ring_buffer__new(bpf_map__fd((*ctx)->probe->maps.ringbuf), ring_buf_cb, (*ctx)->cb_ctx, &opts);
 
     if ((*ctx)->ringbuf == NULL) {
         /* ring_buffer__new doesn't report errors, hard to find something that

--- a/non-GPL/LibEbpfEvents/LibEbpfEvents.h
+++ b/non-GPL/LibEbpfEvents/LibEbpfEvents.h
@@ -40,6 +40,6 @@ int ebpf_event_ctx__new(struct ebpf_event_ctx **ctx,
  */
 int ebpf_event_ctx__next(struct ebpf_event_ctx *ctx, int timeout);
 
-void ebpf_event_ctx__destroy(struct ebpf_event_ctx *ctx);
+void ebpf_event_ctx__destroy(struct ebpf_event_ctx **ctx);
 
 #endif // EBPF_EVENTS_H_


### PR DESCRIPTION
Fixes #49 

This pr implements event filtering for `LibEbpfEvents` and adds the relevant CLI argument sto `EventsTrace` to do the filtering in the program itself.

The two things are done in two separate commits to make reviewing easier.