### PR TITLE
Add setsid/exit probe, flesh out fork/exec probes

### DIFF
--- a/GPL/EventProbe/EbpfEventProto.h
+++ b/GPL/EventProbe/EbpfEventProto.h
@@ -24,9 +24,11 @@
 #endif
 
 enum ebpf_event_type {
-    EBPF_EVENT_PROCESS_FORK = (1 << 1),
-    EBPF_EVENT_PROCESS_EXEC = (1 << 2),
-    EBPF_EVENT_FILE_DELETE  = (1 << 3),
+    EBPF_EVENT_PROCESS_FORK   = (1 << 1),
+    EBPF_EVENT_PROCESS_EXEC   = (1 << 2),
+    EBPF_EVENT_PROCESS_EXIT   = (1 << 3),
+    EBPF_EVENT_PROCESS_SETSID = (1 << 4),
+    EBPF_EVENT_FILE_DELETE    = (1 << 5),
 };
 
 struct ebpf_event_header {
@@ -40,8 +42,21 @@ struct ebpf_file_path {
 } __attribute__((packed));
 
 struct ebpf_pid_info {
+    uint32_t tid;
     uint32_t tgid;
+    uint32_t ppid;
+    uint32_t pgid;
     uint32_t sid;
+    uint64_t start_time_ns;
+} __attribute__((packed));
+
+struct ebpf_cred_info {
+    uint32_t ruid; // Real user ID
+    uint32_t rgid; // Real group ID
+    uint32_t euid; // Effective user ID
+    uint32_t egid; // Effective group ID
+    uint32_t suid; // Saved user ID
+    uint32_t sgid; // Saved group ID
 } __attribute__((packed));
 
 struct ebpf_tty_dev {
@@ -52,25 +67,34 @@ struct ebpf_tty_dev {
 // Full events follow
 struct ebpf_file_delete_event {
     struct ebpf_event_header hdr;
-
     struct ebpf_pid_info pids;
     struct ebpf_file_path path;
 } __attribute__((packed));
 
 struct ebpf_process_fork_event {
     struct ebpf_event_header hdr;
-
     struct ebpf_pid_info parent_pids;
     struct ebpf_pid_info child_pids;
 } __attribute__((packed));
 
 struct ebpf_process_exec_event {
     struct ebpf_event_header hdr;
-
     struct ebpf_pid_info pids;
+    struct ebpf_cred_info creds;
     struct ebpf_tty_dev ctty;
     char filename[PATH_MAX];
+    char cwd[PATH_MAX];
     char argv[ARGV_MAX];
+} __attribute__((packed));
+
+struct ebpf_process_exit_event {
+    struct ebpf_event_header hdr;
+    struct ebpf_pid_info pids;
+} __attribute__((packed));
+
+struct ebpf_process_setsid_event {
+    struct ebpf_event_header hdr;
+    struct ebpf_pid_info pids;
 } __attribute__((packed));
 
 #endif // EBPF_EVENTPROBE_EBPFEVENTPROTO_H

--- a/GPL/EventProbe/EventProbe.bpf.c
+++ b/GPL/EventProbe/EventProbe.bpf.c
@@ -88,9 +88,59 @@ int BPF_PROG(sched_process_exec,
     event->hdr.ts   = bpf_ktime_get_ns();
 
     ebpf_pid_info__fill(&event->pids, task);
+    ebpf_cred_info__fill(&event->creds, task);
     ebpf_ctty__fill(&event->ctty, task);
     ebpf_argv__fill(event->argv, sizeof(event->argv), task);
     bpf_probe_read_kernel_str(event->filename, sizeof(event->filename), binprm->filename);
+
+    bpf_ringbuf_submit(event, 0);
+
+out:
+    return 0;
+}
+
+SEC("tp_btf/sched_process_exit")
+int BPF_PROG(sched_process_exit, const struct task_struct *task)
+{
+    if (is_kernel_thread(task))
+        goto out;
+
+    struct ebpf_process_exit_event *event = bpf_ringbuf_reserve(&ringbuf, sizeof(*event), 0);
+    if (!event)
+        goto out;
+
+    event->hdr.type = EBPF_EVENT_PROCESS_EXIT;
+    event->hdr.ts   = bpf_ktime_get_ns();
+
+    ebpf_pid_info__fill(&event->pids, task);
+
+    bpf_ringbuf_submit(event, 0);
+
+out:
+    return 0;
+}
+
+// tracepoint/syscalls/sys_[enter/exit]_[name] tracepoints are not available
+// with BTF type information, so we must use a non-BTF tracepoint
+SEC("tracepoint/syscalls/sys_exit_setsid")
+int tracepoint_syscalls_sys_exit_setsid(struct trace_event_raw_sys_exit *args)
+{
+    const struct task_struct *task = (struct task_struct *)bpf_get_current_task_btf();
+
+    if (is_kernel_thread(task))
+        goto out;
+
+    if (args->ret < 0)
+        goto out;
+
+    struct ebpf_process_setsid_event *event = bpf_ringbuf_reserve(&ringbuf, sizeof(*event), 0);
+    if (!event)
+        goto out;
+
+    event->hdr.type = EBPF_EVENT_PROCESS_SETSID;
+    event->hdr.ts   = bpf_ktime_get_ns();
+
+    ebpf_pid_info__fill(&event->pids, task);
 
     bpf_ringbuf_submit(event, 0);
 

--- a/GPL/EventProbe/Helpers.h
+++ b/GPL/EventProbe/Helpers.h
@@ -49,8 +49,22 @@ static void ebpf_ctty__fill(struct ebpf_tty_dev *ctty, const struct task_struct 
 
 static void ebpf_pid_info__fill(struct ebpf_pid_info *pi, const struct task_struct *task)
 {
-    pi->tgid = task->tgid;
-    pi->sid  = task->group_leader->signal->pids[PIDTYPE_SID]->numbers[0].nr;
+    pi->tid           = task->pid;
+    pi->tgid          = task->tgid;
+    pi->ppid          = task->group_leader->real_parent->tgid;
+    pi->pgid          = task->group_leader->signal->pids[PIDTYPE_PGID]->numbers[0].nr;
+    pi->sid           = task->group_leader->signal->pids[PIDTYPE_SID]->numbers[0].nr;
+    pi->start_time_ns = task->group_leader->start_time;
+}
+
+static void ebpf_cred_info__fill(struct ebpf_cred_info *ci, const struct task_struct *task)
+{
+    ci->ruid = task->cred->uid.val;
+    ci->euid = task->cred->euid.val;
+    ci->suid = task->cred->suid.val;
+    ci->rgid = task->cred->gid.val;
+    ci->egid = task->cred->egid.val;
+    ci->sgid = task->cred->sgid.val;
 }
 
 static bool is_kernel_thread(const struct task_struct *task)

--- a/non-GPL/EventsTrace/EventsTrace.c
+++ b/non-GPL/EventsTrace/EventsTrace.c
@@ -60,9 +60,14 @@ static void out_event_type(const char *type)
     printf("\"event_type\":\"%s\"", type);
 }
 
-static void out_int(const char *name, const int value)
+static void out_uint(const char *name, const unsigned long value)
 {
-    printf("\"%s\":%d", name, value);
+    printf("\"%s\":%lu", name, value);
+}
+
+static void out_int(const char *name, const long value)
+{
+    printf("\"%s\":%ld", name, value);
 }
 
 static void out_string(const char *name, const char *value)
@@ -84,9 +89,35 @@ static void out_pid_info(const char *name, struct ebpf_pid_info *pid_info)
 {
     printf("\"%s\":", name);
     out_object_start();
+    out_int("tid", pid_info->tid);
+    out_comma();
     out_int("tgid", pid_info->tgid);
     out_comma();
+    out_int("ppid", pid_info->ppid);
+    out_comma();
+    out_int("pgid", pid_info->pgid);
+    out_comma();
     out_int("sid", pid_info->tgid);
+    out_comma();
+    out_uint("start_time_ns", pid_info->start_time_ns);
+    out_object_end();
+}
+
+static void out_cred_info(const char *name, struct ebpf_cred_info *cred_info)
+{
+    printf("\"%s\":", name);
+    out_object_start();
+    out_int("ruid", cred_info->ruid);
+    out_comma();
+    out_int("rgid", cred_info->rgid);
+    out_comma();
+    out_int("euid", cred_info->euid);
+    out_comma();
+    out_int("egid", cred_info->egid);
+    out_comma();
+    out_int("suid", cred_info->suid);
+    out_comma();
+    out_int("sgid", cred_info->sgid);
     out_object_end();
 }
 
@@ -156,6 +187,9 @@ static void out_process_exec(struct ebpf_process_exec_event *evt)
     out_pid_info("pids", &evt->pids);
     out_comma();
 
+    out_cred_info("creds", &evt->creds);
+    out_comma();
+
     out_tty_dev("ctty", &evt->ctty);
     out_comma();
 
@@ -168,19 +202,50 @@ static void out_process_exec(struct ebpf_process_exec_event *evt)
     out_newline();
 }
 
+static void out_process_setsid(struct ebpf_process_setsid_event *evt)
+{
+    out_object_start();
+    out_event_type("PROCESS_SETSID");
+    out_comma();
+
+    out_pid_info("pids", &evt->pids);
+
+    out_object_end();
+    out_newline();
+}
+
+static void out_processs_exit(struct ebpf_process_exit_event *evt)
+{
+    out_object_start();
+    out_event_type("PROCESS_EXIT");
+    out_comma();
+
+    out_pid_info("pids", &evt->pids);
+
+    out_object_end();
+    out_newline();
+}
+
 static int event_ctx_callback(struct ebpf_event_header *evt_hdr)
 {
     switch (evt_hdr->type) {
-    case EBPF_EVENT_FILE_DELETE:
-        out_file_delete((struct ebpf_file_delete_event *)evt_hdr);
-        break;
-
     case EBPF_EVENT_PROCESS_FORK:
         out_process_fork((struct ebpf_process_fork_event *)evt_hdr);
         break;
 
     case EBPF_EVENT_PROCESS_EXEC:
         out_process_exec((struct ebpf_process_exec_event *)evt_hdr);
+        break;
+
+    case EBPF_EVENT_PROCESS_EXIT:
+        out_processs_exit((struct ebpf_process_exit_event *)evt_hdr);
+        break;
+
+    case EBPF_EVENT_PROCESS_SETSID:
+        out_process_setsid((struct ebpf_process_setsid_event *)evt_hdr);
+
+    case EBPF_EVENT_FILE_DELETE:
+        out_file_delete((struct ebpf_file_delete_event *)evt_hdr);
         break;
     }
 


### PR DESCRIPTION
This PR adds a setsid and exit probe and adds more data to the exec probe. Namely, the following information is now collected on exec:

- Creds (uid / gid / etc.)
- More pid info tid/ pgid/ ppid
- Start time (for identifying pid wraps)