### PR TITLE
Disambiguate licensing to GPL 2.0 only

### DIFF
--- a/GPL/EventProbe/BPFEventsTests.cpp
+++ b/GPL/EventProbe/BPFEventsTests.cpp
@@ -1,21 +1,20 @@
-// SPDX-License-Identifier: GPL-2.0
+// SPDX-License-Identifier: GPL-2.0-only
 
 /*
- * Elastic eBPF
- * Copyright 2021 Elasticsearch BV
+ * Copyright (C) 2021 Elasticsearch BV
  *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; version 2.
  *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
  *
- * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
 #include <sys/resource.h>

--- a/GPL/EventProbe/CMakeLists.txt
+++ b/GPL/EventProbe/CMakeLists.txt
@@ -1,22 +1,19 @@
-# SPDX-License-Identifier: GPL-2.0
+# SPDX-License-Identifier: GPL-2.0-only
 
+# Copyright (C) 2021 Elasticsearch BV
 #
-# Elastic eBPF
-# Copyright 2021 Elasticsearch BV
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the Free
+# Software Foundation; version 2.
 #
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+# more details.
 #
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
-#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
 # BPF program
 

--- a/GPL/EventProbe/EbpfEventProto.h
+++ b/GPL/EventProbe/EbpfEventProto.h
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-2.0-only OR LicenseRef-Elastic-License-2.0
+// SPDX-License-Identifier: GPL-2.0-only OR Elastic-2.0
 
 /*
  * Copyright 2021 Elasticsearch BV

--- a/GPL/EventProbe/EbpfEventProto.h
+++ b/GPL/EventProbe/EbpfEventProto.h
@@ -1,6 +1,8 @@
-// SPDX-License-Identifier: GPL-2.0 OR LicenseRef-Elastic-License-2.0
+// SPDX-License-Identifier: GPL-2.0-only OR LicenseRef-Elastic-License-2.0
 
 /*
+ * Copyright 2021 Elasticsearch BV
+ *
  * This file is dual-licensed under the GNU General Public License version 2
  * and the Elastic License 2.0. You may choose either one of them if you use
  * this file.

--- a/GPL/EventProbe/EventProbe.bpf.c
+++ b/GPL/EventProbe/EventProbe.bpf.c
@@ -1,21 +1,20 @@
-// SPDX-License-Identifier: GPL-2.0
+// SPDX-License-Identifier: GPL-2.0-only
 
 /*
- * Elastic eBPF
- * Copyright 2021 Elasticsearch BV
+ * Copyright (C) 2021 Elasticsearch BV
  *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; version 2.
  *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
  *
- * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
 #include "vmlinux.h"

--- a/GPL/EventProbe/File/Probe.bpf.c
+++ b/GPL/EventProbe/File/Probe.bpf.c
@@ -1,21 +1,20 @@
-// SPDX-License-Identifier: GPL-2.0
+// SPDX-License-Identifier: GPL-2.0-only
 
 /*
- * Elastic eBPF
- * Copyright 2021 Elasticsearch BV
+ * Copyright (C) 2021 Elasticsearch BV
  *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; version 2.
  *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
  *
- * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
 #include "vmlinux.h"

--- a/GPL/EventProbe/File/State.h
+++ b/GPL/EventProbe/File/State.h
@@ -1,21 +1,20 @@
-// SPDX-License-Identifier: GPL-2.0
+// SPDX-License-Identifier: GPL-2.0-only
 
 /*
- * Elastic eBPF
- * Copyright 2021 Elasticsearch BV
+ * Copyright (C) 2021 Elasticsearch BV
  *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; version 2.
  *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
  *
- * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
 #ifndef EBPF_EVENTPROBE_FILEEVENTS_STATE_H

--- a/GPL/EventProbe/Helpers.h
+++ b/GPL/EventProbe/Helpers.h
@@ -1,21 +1,20 @@
-// SPDX-License-Identifier: GPL-2.0
+// SPDX-License-Identifier: GPL-2.0-only
 
 /*
- * Elastic eBPF
- * Copyright 2021 Elasticsearch BV
+ * Copyright (C) 2021 Elasticsearch BV
  *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; version 2.
  *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
  *
- * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
 #ifndef EBPF_EVENTPROBE_HELPERS_H

--- a/GPL/EventProbe/Network/Network.h
+++ b/GPL/EventProbe/Network/Network.h
@@ -1,21 +1,20 @@
-// SPDX-License-Identifier: GPL-2.0
+// SPDX-License-Identifier: GPL-2.0-only
 
 /*
- * Elastic eBPF
- * Copyright 2021 Elasticsearch BV
+ * Copyright (C) 2021 Elasticsearch BV
  *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; version 2.
  *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
  *
- * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
 #ifndef EBPF_EVENTPROBE_NETWORK_H

--- a/GPL/EventProbe/Network/Probe.bpf.c
+++ b/GPL/EventProbe/Network/Probe.bpf.c
@@ -1,21 +1,20 @@
-// SPDX-License-Identifier: GPL-2.0
+// SPDX-License-Identifier: GPL-2.0-only
 
 /*
- * Elastic eBPF
- * Copyright 2021 Elasticsearch BV
+ * Copyright (C) 2021 Elasticsearch BV
  *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; version 2.
  *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
  *
- * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
 #include "vmlinux.h"

--- a/GPL/EventProbe/PathResolver.h
+++ b/GPL/EventProbe/PathResolver.h
@@ -1,6 +1,23 @@
 // SPDX-License-Identifier: GPL-2.0-only
 
 /*
+ * Copyright (C) 2021 Elasticsearch BV
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; version 2.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+
+/*
  * BPF dentry resolver
  *
  * This file contains code needed to construct a path as a string from Linux's

--- a/GPL/EventProbe/Process/Probe.bpf.c
+++ b/GPL/EventProbe/Process/Probe.bpf.c
@@ -1,21 +1,20 @@
-// SPDX-License-Identifier: GPL-2.0
+// SPDX-License-Identifier: GPL-2.0-only
 
 /*
- * Elastic eBPF
- * Copyright 2021 Elasticsearch BV
+ * Copyright (C) 2021 Elasticsearch BV
  *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; version 2.
  *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
  *
- * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
 #include "vmlinux.h"

--- a/GPL/HostIsolation/KprobeConnectHook/CMakeLists.txt
+++ b/GPL/HostIsolation/KprobeConnectHook/CMakeLists.txt
@@ -1,22 +1,20 @@
-# SPDX-License-Identifier: GPL-2.0
+# SPDX-License-Identifier: GPL-2.0-only
 
+# Copyright (C) 2021 Elasticsearch BV
 #
-# Elastic eBPF
-# Copyright 2021 Elasticsearch BV
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the Free
+# Software Foundation; version 2.
 #
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+# more details.
 #
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
-#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
 
 # BPF program
 set(KPROBECONNECTHOOK_CFLAGS

--- a/GPL/HostIsolation/KprobeConnectHook/Kerneldefs.h
+++ b/GPL/HostIsolation/KprobeConnectHook/Kerneldefs.h
@@ -1,22 +1,22 @@
-// SPDX-License-Identifier: GPL-2.0
+// SPDX-License-Identifier: GPL-2.0-only
 
 /*
- * Elastic eBPF
- * Copyright 2021 Elasticsearch BV
+ * Copyright (C) 2021 Elasticsearch BV
  *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; version 2.
  *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
  *
- * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
+
 
 typedef signed char __s8;
 

--- a/GPL/HostIsolation/KprobeConnectHook/KprobeConnectHook.bpf.c
+++ b/GPL/HostIsolation/KprobeConnectHook/KprobeConnectHook.bpf.c
@@ -1,22 +1,22 @@
-// SPDX-License-Identifier: GPL-2.0
+// SPDX-License-Identifier: GPL-2.0-only
 
 /*
- * Elastic eBPF
- * Copyright 2021 Elasticsearch BV
+ * Copyright (C) 2021 Elasticsearch BV
  *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; version 2.
  *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
  *
- * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
+
 
 // Host Isolation - this eBPF program hooks into tcp_v4_connect kprobe and adds
 // entries to the IP allowlist if an allowed process tries to initiate a

--- a/GPL/HostIsolation/TcFilter/BPFTcFilterTests.cpp
+++ b/GPL/HostIsolation/TcFilter/BPFTcFilterTests.cpp
@@ -1,21 +1,20 @@
-// SPDX-License-Identifier: GPL-2.0
+// SPDX-License-Identifier: GPL-2.0-only
 
 /*
- * Elastic eBPF
- * Copyright 2021 Elasticsearch BV
+ * Copyright (C) 2021 Elasticsearch BV
  *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; version 2.
  *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
  *
- * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
 #include "Kerneldefs.h"

--- a/GPL/HostIsolation/TcFilter/CMakeLists.txt
+++ b/GPL/HostIsolation/TcFilter/CMakeLists.txt
@@ -1,26 +1,23 @@
-# SPDX-License-Identifier: GPL-2.0
+# SPDX-License-Identifier: GPL-2.0-only
 
+# Copyright (C) 2021 Elasticsearch BV
 #
-# Elastic eBPF
-# Copyright 2021 Elasticsearch BV
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the Free
+# Software Foundation; version 2.
 #
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+# more details.
 #
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
-#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
 
 # BPF program
-
-set(TCFILTER_CFLAGS 
+set(TCFILTER_CFLAGS
                 -g -O2 -nostdinc -isystem ${NOSTDINC_INCLUDES}
                 -I${PROJECT_SOURCE_DIR}/contrib/kernel_hdrs
                 -D__KERNEL__

--- a/GPL/HostIsolation/TcFilter/Kerneldefs.h
+++ b/GPL/HostIsolation/TcFilter/Kerneldefs.h
@@ -1,21 +1,20 @@
-// SPDX-License-Identifier: GPL-2.0
+// SPDX-License-Identifier: GPL-2.0-only
 
 /*
- * Elastic eBPF
- * Copyright 2021 Elasticsearch BV
+ * Copyright (C) 2021 Elasticsearch BV
  *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; version 2.
  *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
  *
- * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
 typedef signed char __s8;

--- a/GPL/HostIsolation/TcFilter/TcFilter.bpf.c
+++ b/GPL/HostIsolation/TcFilter/TcFilter.bpf.c
@@ -1,21 +1,20 @@
-// SPDX-License-Identifier: GPL-2.0
+// SPDX-License-Identifier: GPL-2.0-only
 
 /*
- * Elastic eBPF
- * Copyright 2021 Elasticsearch BV
+ * Copyright (C) 2021 Elasticsearch BV
  *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; version 2.
  *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
  *
- * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
 #include "Kerneldefs.h"

--- a/GPL/HostIsolation/TcFilter/TcFilterdefs.h
+++ b/GPL/HostIsolation/TcFilter/TcFilterdefs.h
@@ -1,21 +1,20 @@
-// SPDX-License-Identifier: GPL-2.0
+// SPDX-License-Identifier: GPL-2.0-only
 
 /*
- * Elastic eBPF
- * Copyright 2021 Elasticsearch BV
+ * Copyright (C) 2021 Elasticsearch BV
  *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; version 2.
  *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
  *
- * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
 #ifndef TC_FILTERDEFS_H

--- a/non-GPL/Common/Common.c
+++ b/non-GPL/Common/Common.c
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LicenseRef-Elastic-License-2.0
+// SPDX-License-Identifier: Elastic-2.0
 
 /*
  * Copyright 2021 Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under

--- a/non-GPL/Common/Common.h
+++ b/non-GPL/Common/Common.h
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LicenseRef-Elastic-License-2.0
+// SPDX-License-Identifier: Elastic-2.0
 
 /*
  * Copyright 2021 Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under

--- a/non-GPL/EventsTrace/EventsTrace.c
+++ b/non-GPL/EventsTrace/EventsTrace.c
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LicenseRef-Elastic-License-2.0
+// SPDX-License-Identifier: Elastic-2.0
 
 /*
  * Copyright 2021 Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under

--- a/non-GPL/HostIsolation/KprobeConnectHook/KprobeConnectHookDemo.c
+++ b/non-GPL/HostIsolation/KprobeConnectHook/KprobeConnectHookDemo.c
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LicenseRef-Elastic-License-2.0
+// SPDX-License-Identifier: Elastic-2.0
 
 /*
  * Copyright 2021 Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under

--- a/non-GPL/HostIsolation/KprobeConnectHook/KprobeLoader.c
+++ b/non-GPL/HostIsolation/KprobeConnectHook/KprobeLoader.c
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LicenseRef-Elastic-License-2.0
+// SPDX-License-Identifier: Elastic-2.0
 
 /*
  * Copyright 2021 Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under

--- a/non-GPL/HostIsolation/KprobeConnectHook/KprobeLoader.h
+++ b/non-GPL/HostIsolation/KprobeConnectHook/KprobeLoader.h
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LicenseRef-Elastic-License-2.0
+// SPDX-License-Identifier: Elastic-2.0
 
 /*
  * Copyright 2021 Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under

--- a/non-GPL/HostIsolationMapsUtil/UpdateIPsDemo.c
+++ b/non-GPL/HostIsolationMapsUtil/UpdateIPsDemo.c
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LicenseRef-Elastic-License-2.0
+// SPDX-License-Identifier: Elastic-2.0
 
 /*
  * Copyright 2021 Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under

--- a/non-GPL/HostIsolationMapsUtil/UpdateMaps.c
+++ b/non-GPL/HostIsolationMapsUtil/UpdateMaps.c
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LicenseRef-Elastic-License-2.0
+// SPDX-License-Identifier: Elastic-2.0
 
 /*
  * Copyright 2021 Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under

--- a/non-GPL/HostIsolationMapsUtil/UpdateMaps.h
+++ b/non-GPL/HostIsolationMapsUtil/UpdateMaps.h
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LicenseRef-Elastic-License-2.0
+// SPDX-License-Identifier: Elastic-2.0
 
 /*
  * Copyright 2021 Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under

--- a/non-GPL/HostIsolationMapsUtil/UpdatePidsDemo.c
+++ b/non-GPL/HostIsolationMapsUtil/UpdatePidsDemo.c
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LicenseRef-Elastic-License-2.0
+// SPDX-License-Identifier: Elastic-2.0
 
 /*
  * Copyright 2021 Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under

--- a/non-GPL/LibEbpfEvents/LibEbpfEvents.c
+++ b/non-GPL/LibEbpfEvents/LibEbpfEvents.c
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LicenseRef-Elastic-License-2.0
+// SPDX-License-Identifier: Elastic-2.0
 
 /*
  * Copyright 2021 Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under

--- a/non-GPL/LibEbpfEvents/LibEbpfEvents.h
+++ b/non-GPL/LibEbpfEvents/LibEbpfEvents.h
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LicenseRef-Elastic-License-2.0
+// SPDX-License-Identifier: Elastic-2.0
 
 /*
  * Copyright 2021 Elasticsearch B.V. and/or licensed to Elasticsearch B.V.

--- a/non-GPL/TcLoader/TcLoader.c
+++ b/non-GPL/TcLoader/TcLoader.c
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LicenseRef-Elastic-License-2.0
+// SPDX-License-Identifier: Elastic-2.0
 
 /*
  * Copyright 2021 Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under

--- a/non-GPL/TcLoader/TcLoader.h
+++ b/non-GPL/TcLoader/TcLoader.h
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LicenseRef-Elastic-License-2.0
+// SPDX-License-Identifier: Elastic-2.0
 
 /*
  * Copyright 2021 Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under

--- a/non-GPL/TcLoader/TcLoaderDemo.c
+++ b/non-GPL/TcLoader/TcLoaderDemo.c
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LicenseRef-Elastic-License-2.0
+// SPDX-License-Identifier: Elastic-2.0
 
 /*
  * Copyright 2021 Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under


### PR DESCRIPTION
There were two problems with the license headers as things stood:

- The SPDX license identifiers used the deprecated "GPL-2.0" instead of
  the newer and less ambigous "GPL-2.0-only"
- The longer GPL header comments all stated that the files were licensed
  under GPL v3 or later, while the SPDX identifier above said GPL 2.0

This commit changes all the SPDX "GPL-2.0" headers to "GPL-2.0-only" and
removes the longer GPL header comments entirely. It seems the FSF
doesn't have a version that states GPL 2/3 _only_ and the license is
stated in the SPDX identifier (and LICENSE file ) anyways, so it's
redundant.

CC: @stanek-michal you last changed licensing in a major way (dbca96c1173d09bee9ffca915f8f7bcdc0bad40b) so want your sign-off on this before I merge.

This PR also updates the `LicenseRef-Elastic-License-2.0` SPDX identifiers to simply `Elastic-2.0`, since it's now officially part of the SPDX spec.