### PR TITLE
Use BTF-defined map defs and change PathResolver scratch map to a percpu-array

### DIFF
--- a/GPL/EventProbe/FileEventsHelpers.h
+++ b/GPL/EventProbe/FileEventsHelpers.h
@@ -54,12 +54,12 @@ struct ebpf_fileevents_state {
     };
 };
 
-struct bpf_map_def SEC("maps") elastic_ebpf_fileevents_state = {
-    .type        = BPF_MAP_TYPE_LRU_HASH,
-    .key_size    = sizeof(struct ebpf_fileevents_key),
-    .value_size  = sizeof(struct ebpf_fileevents_state),
-    .max_entries = 4096,
-};
+struct {
+    __uint(type, BPF_MAP_TYPE_LRU_HASH);
+    __type(key, struct ebpf_fileevents_key);
+    __type(value, struct ebpf_fileevents_state);
+    __uint(max_entries, 4096);
+} elastic_ebpf_fileevents_state SEC(".maps");
 
 static struct ebpf_fileevents_key ebpf_fileevents_state__key(enum ebpf_fileevents_state_op op)
 {
@@ -99,19 +99,19 @@ struct ebpf_fileevents_scratch_space {
 /* This map is only used to initialize a "ebpf_fileevents_scratch_space" as
  * due to bpf stack size limitations, it can't be done in the program itself.
  */
-struct bpf_map_def SEC("maps") elastic_ebpf_fileevents_init_buffer = {
-    .type        = BPF_MAP_TYPE_PERCPU_ARRAY,
-    .key_size    = sizeof(u32),
-    .value_size  = sizeof(struct ebpf_fileevents_scratch_space),
-    .max_entries = 1,
-};
+struct {
+    __uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
+    __type(key, u32);
+    __type(value, struct ebpf_fileevents_scratch_space);
+    __uint(max_entries, 1);
+} elastic_ebpf_fileevents_init_buffer SEC(".maps");
 
-struct bpf_map_def SEC("maps") elastic_ebpf_fileevents_scratch_space = {
-    .type        = BPF_MAP_TYPE_LRU_HASH,
-    .key_size    = sizeof(struct ebpf_fileevents_key),
-    .value_size  = sizeof(struct ebpf_fileevents_scratch_space),
-    .max_entries = 512,
-};
+struct {
+    __uint(type, BPF_MAP_TYPE_LRU_HASH);
+    __type(key, struct ebpf_fileevents_key);
+    __type(value, struct ebpf_fileevents_scratch_space);
+    __uint(max_entries, 512);
+} elastic_ebpf_fileevents_scratch_space SEC(".maps");
 
 static struct ebpf_fileevents_scratch_space *
 ebpf_fileevents_scratch_space__get(enum ebpf_fileevents_state_op op)

--- a/GPL/EventProbe/Maps.h
+++ b/GPL/EventProbe/Maps.h
@@ -4,9 +4,9 @@
 // todo(fntlnz): another buffer will probably need
 // to be used instead of this one as the common parts evolve
 // to have a shared buffer between File, Network and Process.
-struct bpf_map_def SEC("maps") ringbuf = {
-    .type        = BPF_MAP_TYPE_RINGBUF,
-    .max_entries = 4096 * 64, // todo: Need to verify if 256 kb is what we want
-};
+struct {
+    __uint(type, BPF_MAP_TYPE_RINGBUF);
+    __uint(max_entries, 4096 * 64); // todo: Need to verify if 256 kb is what we want
+} ringbuf SEC(".maps");
 
 #endif // EBPF_EVENTPROBE_MAPS_H

--- a/GPL/EventProbe/PathResolver.h
+++ b/GPL/EventProbe/PathResolver.h
@@ -35,12 +35,12 @@
 
 // Map used as a scratch area by the path resolver to store intermediate state
 // (dentry pointers). Indexed by CPU number.
-struct bpf_map_def SEC("maps") path_resolver_scratch_map = {
-    .type        = BPF_MAP_TYPE_ARRAY,
-    .max_entries = 128,
-    .key_size    = sizeof(uint32_t),
-    .value_size  = sizeof(struct dentry *) * PATH_RESOLVER_MAX_COMPONENTS,
-};
+struct {
+    __uint(type, BPF_MAP_TYPE_ARRAY);
+    __type(key, u32);
+    __type(value, struct dentry *[PATH_RESOLVER_MAX_COMPONENTS]);
+    __uint(max_entries, 128);
+} path_resolver_scratch_map SEC(".maps");
 
 static void
 ebpf_resolve_path_to_string(char *buf, struct path *path, const struct task_struct *task)


### PR DESCRIPTION
Closes https://github.com/elastic/ebpf/issues/68

@rhysre I've changed the scratch map in PathResolver to a percpu-array since the execution is always in the context of a single ebpf program. Let me know if that's ok for you
