### PR TITLE
Network events

### DIFF
--- a/GPL/EventProbe/EbpfEventProto.h
+++ b/GPL/EventProbe/EbpfEventProto.h
@@ -33,6 +33,7 @@ enum ebpf_event_type {
     EBPF_EVENT_FILE_RENAME                  = (1 << 7),
     EBPF_EVENT_NETWORK_CONNECTION_ACCEPTED  = (1 << 8),
     EBPF_EVENT_NETWORK_CONNECTION_ATTEMPTED = (1 << 9),
+    EBPF_EVENT_NETWORK_CONNECTION_CLOSED    = (1 << 10),
 };
 
 struct ebpf_event_header {

--- a/GPL/EventProbe/EbpfEventProto.h
+++ b/GPL/EventProbe/EbpfEventProto.h
@@ -24,13 +24,14 @@
 #endif
 
 enum ebpf_event_type {
-    EBPF_EVENT_PROCESS_FORK   = (1 << 1),
-    EBPF_EVENT_PROCESS_EXEC   = (1 << 2),
-    EBPF_EVENT_PROCESS_EXIT   = (1 << 3),
-    EBPF_EVENT_PROCESS_SETSID = (1 << 4),
-    EBPF_EVENT_FILE_DELETE    = (1 << 5),
-    EBPF_EVENT_FILE_CREATE    = (1 << 6),
-    EBPF_EVENT_FILE_RENAME    = (1 << 7),
+    EBPF_EVENT_PROCESS_FORK                = (1 << 1),
+    EBPF_EVENT_PROCESS_EXEC                = (1 << 2),
+    EBPF_EVENT_PROCESS_EXIT                = (1 << 3),
+    EBPF_EVENT_PROCESS_SETSID              = (1 << 4),
+    EBPF_EVENT_FILE_DELETE                 = (1 << 5),
+    EBPF_EVENT_FILE_CREATE                 = (1 << 6),
+    EBPF_EVENT_FILE_RENAME                 = (1 << 7),
+    EBPF_EVENT_NETWORK_CONNECTION_ACCEPTED = (1 << 8),
 };
 
 struct ebpf_event_header {
@@ -106,6 +107,32 @@ struct ebpf_process_exit_event {
 struct ebpf_process_setsid_event {
     struct ebpf_event_header hdr;
     struct ebpf_pid_info pids;
+} __attribute__((packed));
+
+enum ebpf_net_info_af {
+    EBPF_NETWORK_EVENT_AF_INET  = 1,
+    EBPF_NETWORK_EVENT_AF_INET6 = 2,
+};
+
+struct ebpf_net_info {
+    enum ebpf_net_info_af family;
+    union {
+        uint8_t saddr[4];
+        uint8_t saddr6[16];
+    }; // Network byte order
+    union {
+        uint8_t daddr[4];
+        uint8_t daddr6[16];
+    }; // Network byte order
+    uint16_t sport;
+    uint16_t dport;
+    uint32_t netns;
+} __attribute__((packed));
+
+struct ebpf_net_connection_accepted_event {
+    struct ebpf_event_header hdr;
+    struct ebpf_pid_info pids;
+    struct ebpf_net_info net;
 } __attribute__((packed));
 
 #endif // EBPF_EVENTPROBE_EBPFEVENTPROTO_H

--- a/GPL/EventProbe/EbpfEventProto.h
+++ b/GPL/EventProbe/EbpfEventProto.h
@@ -111,6 +111,10 @@ struct ebpf_process_setsid_event {
     struct ebpf_pid_info pids;
 } __attribute__((packed));
 
+enum ebpf_net_info_transport {
+    EBPF_NETWORK_EVENT_TRANSPORT_TCP = 1,
+};
+
 enum ebpf_net_info_af {
     EBPF_NETWORK_EVENT_AF_INET  = 1,
     EBPF_NETWORK_EVENT_AF_INET6 = 2,
@@ -122,6 +126,7 @@ struct ebpf_net_info_tcp_close {
 } __attribute__((packed));
 
 struct ebpf_net_info {
+    enum ebpf_net_info_transport transport;
     enum ebpf_net_info_af family;
     union {
         uint8_t saddr[4];

--- a/GPL/EventProbe/EbpfEventProto.h
+++ b/GPL/EventProbe/EbpfEventProto.h
@@ -136,8 +136,8 @@ struct ebpf_net_info {
         uint8_t daddr[4];
         uint8_t daddr6[16];
     }; // Network byte order
-    uint16_t sport;
-    uint16_t dport;
+    uint16_t sport; // Host byte order
+    uint16_t dport; // Host byte order
     uint32_t netns;
     union {
         struct ebpf_net_info_tcp_close close;

--- a/GPL/EventProbe/EbpfEventProto.h
+++ b/GPL/EventProbe/EbpfEventProto.h
@@ -116,6 +116,11 @@ enum ebpf_net_info_af {
     EBPF_NETWORK_EVENT_AF_INET6 = 2,
 };
 
+struct ebpf_net_info_tcp_close {
+    uint64_t bytes_sent;
+    uint64_t bytes_received;
+} __attribute__((packed));
+
 struct ebpf_net_info {
     enum ebpf_net_info_af family;
     union {
@@ -129,12 +134,16 @@ struct ebpf_net_info {
     uint16_t sport;
     uint16_t dport;
     uint32_t netns;
+    union {
+        struct ebpf_net_info_tcp_close close;
+    } tcp;
 } __attribute__((packed));
 
 struct ebpf_net_event {
     struct ebpf_event_header hdr;
     struct ebpf_pid_info pids;
     struct ebpf_net_info net;
+    char comm[16]; // TASK_COMM_LEN
 } __attribute__((packed));
 
 #endif // EBPF_EVENTPROBE_EBPFEVENTPROTO_H

--- a/GPL/EventProbe/EbpfEventProto.h
+++ b/GPL/EventProbe/EbpfEventProto.h
@@ -24,14 +24,15 @@
 #endif
 
 enum ebpf_event_type {
-    EBPF_EVENT_PROCESS_FORK                = (1 << 1),
-    EBPF_EVENT_PROCESS_EXEC                = (1 << 2),
-    EBPF_EVENT_PROCESS_EXIT                = (1 << 3),
-    EBPF_EVENT_PROCESS_SETSID              = (1 << 4),
-    EBPF_EVENT_FILE_DELETE                 = (1 << 5),
-    EBPF_EVENT_FILE_CREATE                 = (1 << 6),
-    EBPF_EVENT_FILE_RENAME                 = (1 << 7),
-    EBPF_EVENT_NETWORK_CONNECTION_ACCEPTED = (1 << 8),
+    EBPF_EVENT_PROCESS_FORK                 = (1 << 1),
+    EBPF_EVENT_PROCESS_EXEC                 = (1 << 2),
+    EBPF_EVENT_PROCESS_EXIT                 = (1 << 3),
+    EBPF_EVENT_PROCESS_SETSID               = (1 << 4),
+    EBPF_EVENT_FILE_DELETE                  = (1 << 5),
+    EBPF_EVENT_FILE_CREATE                  = (1 << 6),
+    EBPF_EVENT_FILE_RENAME                  = (1 << 7),
+    EBPF_EVENT_NETWORK_CONNECTION_ACCEPTED  = (1 << 8),
+    EBPF_EVENT_NETWORK_CONNECTION_ATTEMPTED = (1 << 9),
 };
 
 struct ebpf_event_header {
@@ -129,7 +130,7 @@ struct ebpf_net_info {
     uint32_t netns;
 } __attribute__((packed));
 
-struct ebpf_net_connection_accepted_event {
+struct ebpf_net_event {
     struct ebpf_event_header hdr;
     struct ebpf_pid_info pids;
     struct ebpf_net_info net;

--- a/GPL/EventProbe/File/Probe.bpf.c
+++ b/GPL/EventProbe/File/Probe.bpf.c
@@ -20,8 +20,8 @@
 
 #include "vmlinux.h"
 
-#include <bpf/bpf_helpers.h>
 #include <bpf/bpf_core_read.h>
+#include <bpf/bpf_helpers.h>
 #include <bpf/bpf_tracing.h>
 
 #include "Helpers.h"

--- a/GPL/EventProbe/Network/Network.h
+++ b/GPL/EventProbe/Network/Network.h
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: GPL-2.0
+
+/*
+ * Elastic eBPF
+ * Copyright 2021 Elasticsearch BV
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#ifndef EBPF_EVENTPROBE_NETWORK_H
+#define EBPF_EVENTPROBE_NETWORK_H
+
+// linux/socket.h
+#define AF_INET 2
+#define AF_INET6 10
+
+static int ebpf_sock_info__fill(struct ebpf_net_info *net, struct sock *sk)
+{
+    int err = 0;
+
+    u16 family = BPF_CORE_READ(sk, __sk_common.skc_family);
+    switch (family) {
+    case AF_INET:
+        err = BPF_CORE_READ_INTO(&net->saddr, sk, __sk_common.skc_rcv_saddr);
+        if (err) {
+            bpf_printk("AF_INET: error while reading saddr");
+            goto out;
+        }
+
+        err = BPF_CORE_READ_INTO(&net->daddr, sk, __sk_common.skc_daddr);
+        if (err) {
+            bpf_printk("AF_INET: error while reading daddr");
+            goto out;
+        }
+
+        net->family = EBPF_NETWORK_EVENT_AF_INET;
+        break;
+    case AF_INET6:
+        err = BPF_CORE_READ_INTO(&net->saddr6, sk, __sk_common.skc_v6_rcv_saddr);
+        if (err) {
+            bpf_printk("AF_INET6: error while reading saddr");
+            goto out;
+        }
+
+        err = BPF_CORE_READ_INTO(&net->daddr6, sk, __sk_common.skc_v6_daddr);
+        if (err) {
+            bpf_printk("AF_INET6: error while reading daddr");
+            goto out;
+        }
+
+        net->family = EBPF_NETWORK_EVENT_AF_INET6;
+        break;
+    default:
+        err = -1;
+        goto out;
+    }
+
+    struct inet_sock *inet = (struct inet_sock *)sk;
+    u16 sport              = BPF_CORE_READ(inet, inet_sport);
+    net->sport             = bpf_ntohs(sport);
+    u16 dport              = BPF_CORE_READ(sk, __sk_common.skc_dport);
+    net->dport             = bpf_ntohs(dport);
+    net->netns             = BPF_CORE_READ(sk, __sk_common.skc_net.net, ns.inum);
+
+out:
+    return err;
+}
+
+#endif // EBPF_EVENTPROBE_NETWORK_H

--- a/GPL/EventProbe/Network/Probe.bpf.c
+++ b/GPL/EventProbe/Network/Probe.bpf.c
@@ -17,3 +17,41 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
+
+#include "vmlinux.h"
+
+#include <bpf/bpf_core_read.h>
+#include <bpf/bpf_endian.h>
+#include <bpf/bpf_helpers.h>
+#include <bpf/bpf_tracing.h>
+
+#include "Helpers.h"
+#include "Network.h"
+
+SEC("fexit/inet_csk_accept")
+int BPF_PROG(
+    fexit__inet_csk_accept, struct sock *sk, int flags, int *err, bool kern, struct sock *ret)
+{
+    if (!ret)
+        goto out;
+
+    struct ebpf_net_connection_accepted_event *event =
+        bpf_ringbuf_reserve(&ringbuf, sizeof(*event), 0);
+    if (!event)
+        goto out;
+
+    if (ebpf_sock_info__fill(&event->net, ret)) {
+        bpf_ringbuf_discard(event, 0);
+        goto out;
+    }
+
+    struct task_struct *task = (struct task_struct *)bpf_get_current_task();
+    ebpf_pid_info__fill(&event->pids, task);
+    event->hdr.ts   = bpf_ktime_get_ns();
+    event->hdr.type = EBPF_EVENT_NETWORK_CONNECTION_ACCEPTED;
+
+    bpf_ringbuf_submit(event, 0);
+
+out:
+    return 0;
+}

--- a/GPL/EventProbe/Network/Probe.bpf.c
+++ b/GPL/EventProbe/Network/Probe.bpf.c
@@ -87,6 +87,10 @@ int BPF_PROG(fexit__tcp_v6_connect, struct sock *sk, struct sockaddr *uaddr, int
 SEC("fentry/tcp_close")
 int BPF_PROG(fentry__tcp_close, struct sock *sk, long timeout)
 {
+    unsigned char state = BPF_CORE_READ(sk, __sk_common.skc_state);
+    if (state == TCP_CLOSE)
+        goto out;
+
     struct ebpf_net_event *event = bpf_ringbuf_reserve(&ringbuf, sizeof(*event), 0);
     if (!event)
         goto out;

--- a/GPL/EventProbe/Process/Probe.bpf.c
+++ b/GPL/EventProbe/Process/Probe.bpf.c
@@ -20,8 +20,8 @@
 
 #include "vmlinux.h"
 
-#include <bpf/bpf_helpers.h>
 #include <bpf/bpf_core_read.h>
+#include <bpf/bpf_helpers.h>
 #include <bpf/bpf_tracing.h>
 
 #include "Helpers.h"

--- a/non-GPL/EventsTrace/EventsTrace.c
+++ b/non-GPL/EventsTrace/EventsTrace.c
@@ -393,10 +393,10 @@ static void out_net_info(const char *name, struct ebpf_net_event *evt)
     switch (evt->hdr.type) {
     case EBPF_EVENT_NETWORK_CONNECTION_CLOSED:
         out_comma();
-        out_int("bytes_sent", net->tcp.close.bytes_sent);
+        out_uint("bytes_sent", net->tcp.close.bytes_sent);
 
         out_comma();
-        out_int("bytes_received", net->tcp.close.bytes_received);
+        out_uint("bytes_received", net->tcp.close.bytes_received);
         break;
     }
 

--- a/non-GPL/EventsTrace/EventsTrace.c
+++ b/non-GPL/EventsTrace/EventsTrace.c
@@ -29,7 +29,7 @@ const char argp_program_doc[] =
     "\n"
     "USAGE: ./EventsTrace [--all|-a] [--file-delete] [--file-create] [--file-rename]\n"
     "[--process-fork] [--process-exec] [--process-exit] [--process-setsid]\n"
-    "[--net-conn-accept]\n";
+    "[--net-conn-accept] [--net-conn-attempt] [--net-conn-closed]\n";
 
 static const struct argp_option opts[] = {
     {"all", 'a', NULL, false, "Whether or not to consider all the events", 0},
@@ -51,6 +51,8 @@ static const struct argp_option opts[] = {
      "Whether or not to consider network connection accepted events", 1},
     {"net-conn-attempt", EBPF_EVENT_NETWORK_CONNECTION_ATTEMPTED, NULL, false,
      "Whether or not to consider network connection attempted events", 1},
+    {"net-conn-closed", EBPF_EVENT_NETWORK_CONNECTION_CLOSED, NULL, false,
+     "Whether or not to consider network connection closed events", 1},
     {},
 };
 
@@ -71,6 +73,7 @@ static error_t parse_arg(int key, char *arg, struct argp_state *state)
     case EBPF_EVENT_PROCESS_SETSID:
     case EBPF_EVENT_NETWORK_CONNECTION_ACCEPTED:
     case EBPF_EVENT_NETWORK_CONNECTION_ATTEMPTED:
+    case EBPF_EVENT_NETWORK_CONNECTION_CLOSED:
         g_events_env |= key;
         break;
     case ARGP_KEY_ARG:
@@ -403,6 +406,11 @@ static void out_network_connection_attempted_event(struct ebpf_net_event *evt)
     out_network_event("NETWORK_CONNECTION_ATTEMPTED", evt);
 }
 
+static void out_network_connection_closed_event(struct ebpf_net_event *evt)
+{
+    out_network_event("NETWORK_CONNECTION_CLOSED", evt);
+}
+
 static int event_ctx_callback(struct ebpf_event_header *evt_hdr)
 {
     switch (evt_hdr->type) {
@@ -432,6 +440,9 @@ static int event_ctx_callback(struct ebpf_event_header *evt_hdr)
         break;
     case EBPF_EVENT_NETWORK_CONNECTION_ATTEMPTED:
         out_network_connection_attempted_event((struct ebpf_net_event *)evt_hdr);
+        break;
+    case EBPF_EVENT_NETWORK_CONNECTION_CLOSED:
+        out_network_connection_closed_event((struct ebpf_net_event *)evt_hdr);
         break;
     }
 

--- a/non-GPL/EventsTrace/EventsTrace.c
+++ b/non-GPL/EventsTrace/EventsTrace.c
@@ -341,8 +341,10 @@ static void out_ip6_addr(const char *name, const void *addr)
     printf("\"%s\":\"%s\"", name, buf);
 }
 
-static void out_net_info(const char *name, struct ebpf_net_info *net)
+static void out_net_info(const char *name, struct ebpf_net_event *evt)
 {
+    struct ebpf_net_info *net = &evt->net;
+
     printf("\"%s\":", name);
     out_object_start();
 
@@ -378,6 +380,14 @@ static void out_net_info(const char *name, struct ebpf_net_info *net)
     out_comma();
     out_int("network_namespace", net->netns);
 
+    if (evt->hdr.type == EBPF_EVENT_NETWORK_CONNECTION_CLOSED) {
+        out_comma();
+        out_int("bytes_sent", net->tcp.close.bytes_sent);
+
+        out_comma();
+        out_int("bytes_received", net->tcp.close.bytes_received);
+    }
+
     out_object_end();
 }
 
@@ -390,7 +400,10 @@ static void out_network_event(const char *name, struct ebpf_net_event *evt)
     out_pid_info("pids", &evt->pids);
     out_comma();
 
-    out_net_info("net", &evt->net);
+    out_net_info("net", evt);
+    out_comma();
+
+    out_string("comm", (const char *)&evt->comm);
 
     out_object_end();
     out_newline();

--- a/non-GPL/EventsTrace/EventsTrace.c
+++ b/non-GPL/EventsTrace/EventsTrace.c
@@ -348,7 +348,15 @@ static void out_net_info(const char *name, struct ebpf_net_event *evt)
     printf("\"%s\":", name);
     out_object_start();
 
-    if (net->family == EBPF_NETWORK_EVENT_AF_INET) {
+    switch (net->transport) {
+    case EBPF_NETWORK_EVENT_TRANSPORT_TCP:
+        out_string("transport", "TCP");
+        out_comma();
+        break;
+    }
+
+    switch (net->family) {
+    case EBPF_NETWORK_EVENT_AF_INET:
         out_string("family", "AF_INET");
         out_comma();
 
@@ -362,7 +370,8 @@ static void out_net_info(const char *name, struct ebpf_net_event *evt)
         out_comma();
 
         out_int("destination_port", net->dport);
-    } else {
+        break;
+    case EBPF_NETWORK_EVENT_AF_INET6:
         out_string("family", "AF_INET6");
 
         out_ip6_addr("source_address", &net->saddr6);
@@ -375,17 +384,20 @@ static void out_net_info(const char *name, struct ebpf_net_event *evt)
         out_comma();
 
         out_int("destination_port", net->dport);
+        break;
     }
 
     out_comma();
     out_int("network_namespace", net->netns);
 
-    if (evt->hdr.type == EBPF_EVENT_NETWORK_CONNECTION_CLOSED) {
+    switch (evt->hdr.type) {
+    case EBPF_EVENT_NETWORK_CONNECTION_CLOSED:
         out_comma();
         out_int("bytes_sent", net->tcp.close.bytes_sent);
 
         out_comma();
         out_int("bytes_received", net->tcp.close.bytes_received);
+        break;
     }
 
     out_object_end();


### PR DESCRIPTION
To do / discuss:
- [x] clarify what "disconnect received" means: [tcp_close](https://elixir.bootlin.com/linux/v5.16.7/source/net/ipv4/tcp_ipv4.c#L3058) or [tcp_disconnect](https://elixir.bootlin.com/linux/v5.16.7/source/net/ipv4/tcp_ipv4.c#L3061) ? rename event?
- [x] clarify what "connection attempted" means: only successful attempts? rename event?
- [x] test ipv6
- [x] check if any func signature has changed from 5.x to 5.16
- [x] doing stuff in a container generates 2 events (host netns and container netns), eg:
```
{"family":"AF_INET","source_address":"10.0.2.100","source_port":42270,"destination_address":"157.90.119.155","destination_port":443,"network_namespace":4026534259}
{"family":"AF_INET","source_address":"192.168.1.3","source_port":43526,"destination_address":"157.90.119.155","destination_port":443,"network_namespace":4026532008}
``` 
Why it happened: we debugged this with @fntlnz and discovered that the second event was being triggered by [slirp4netns](https://github.com/rootless-containers/slirp4netns) because I was using Podman in rootless mode. This doesn't happen using Docker

- [x] add `bytes_sent` and `bytes_received` on `tcp_close`
- [x] add transport field

Closes https://github.com/elastic/ebpf/issues/61
Closes https://github.com/elastic/ebpf/issues/62
Closes https://github.com/elastic/ebpf/issues/63