### PR TITLE
Default to using builtin vmlinux

### DIFF
--- a/cmake/modules/BPF.cmake
+++ b/cmake/modules/BPF.cmake
@@ -12,7 +12,7 @@ set(LLC "llc")
 set(LLVM_STRIP "llvm-strip")
 set(BPFTOOL "bpftool")
 set(BTF_FILE "/sys/kernel/btf/vmlinux")
-option(USE_BUILTIN_VMLINUX "Whether or not to use the builtin vmlinux.h for building the BPF programs instead of trying to generate one from the system" False)
+option(USE_BUILTIN_VMLINUX "Whether or not to use the builtin vmlinux.h for building the BPF programs instead of trying to generate one from the system" True)
 
 # Standard includes
 execute_process(COMMAND ${CLANG} -print-file-name=include


### PR DESCRIPTION
Set USE_BUILTIN_VMLINUX to default to True.

On systems with kernels that don't provide BTF info, the build will fail
when the builtin vmlinux is not used. So defaulting to use builtin
vmlinux is the safer/more compatible build option.