### PR TITLE
Add setuid/setgid events

### DIFF
--- a/GPL/EventProbe/EbpfEventProto.h
+++ b/GPL/EventProbe/EbpfEventProto.h
@@ -30,12 +30,14 @@ enum ebpf_event_type {
     EBPF_EVENT_PROCESS_EXEC                 = (1 << 2),
     EBPF_EVENT_PROCESS_EXIT                 = (1 << 3),
     EBPF_EVENT_PROCESS_SETSID               = (1 << 4),
-    EBPF_EVENT_FILE_DELETE                  = (1 << 5),
-    EBPF_EVENT_FILE_CREATE                  = (1 << 6),
-    EBPF_EVENT_FILE_RENAME                  = (1 << 7),
-    EBPF_EVENT_NETWORK_CONNECTION_ACCEPTED  = (1 << 8),
-    EBPF_EVENT_NETWORK_CONNECTION_ATTEMPTED = (1 << 9),
-    EBPF_EVENT_NETWORK_CONNECTION_CLOSED    = (1 << 10),
+    EBPF_EVENT_PROCESS_SETUID               = (1 << 5),
+    EBPF_EVENT_PROCESS_SETGID               = (1 << 6),
+    EBPF_EVENT_FILE_DELETE                  = (1 << 7),
+    EBPF_EVENT_FILE_CREATE                  = (1 << 8),
+    EBPF_EVENT_FILE_RENAME                  = (1 << 9),
+    EBPF_EVENT_NETWORK_CONNECTION_ACCEPTED  = (1 << 10),
+    EBPF_EVENT_NETWORK_CONNECTION_ATTEMPTED = (1 << 11),
+    EBPF_EVENT_NETWORK_CONNECTION_CLOSED    = (1 << 12),
 };
 
 struct ebpf_event_header {
@@ -113,6 +115,18 @@ struct ebpf_process_setsid_event {
     struct ebpf_pid_info pids;
 } __attribute__((packed));
 
+struct ebpf_process_setuid_event {
+    struct ebpf_event_header hdr;
+    struct ebpf_pid_info pids;
+    struct ebpf_cred_info creds;
+} __attribute__((packed));
+
+struct ebpf_process_setgid_event {
+    struct ebpf_event_header hdr;
+    struct ebpf_pid_info pids;
+    struct ebpf_cred_info creds;
+} __attribute__((packed));
+
 enum ebpf_net_info_transport {
     EBPF_NETWORK_EVENT_TRANSPORT_TCP = 1,
 };
@@ -137,7 +151,7 @@ struct ebpf_net_info {
     union {
         uint8_t daddr[4];
         uint8_t daddr6[16];
-    }; // Network byte order
+    };              // Network byte order
     uint16_t sport; // Host byte order
     uint16_t dport; // Host byte order
     uint32_t netns;

--- a/GPL/HostIsolation/KprobeConnectHook/Kerneldefs.h
+++ b/GPL/HostIsolation/KprobeConnectHook/Kerneldefs.h
@@ -17,7 +17,6 @@
  * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
-
 typedef signed char __s8;
 
 typedef unsigned char __u8;

--- a/GPL/HostIsolation/KprobeConnectHook/KprobeConnectHook.bpf.c
+++ b/GPL/HostIsolation/KprobeConnectHook/KprobeConnectHook.bpf.c
@@ -17,7 +17,6 @@
  * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
-
 // Host Isolation - this eBPF program hooks into tcp_v4_connect kprobe and adds
 // entries to the IP allowlist if an allowed process tries to initiate a
 // connection.


### PR DESCRIPTION
Adds setuid/setgid events. These are not required for any of the "wide events" that we need to build session view, but we need them for compatibility with the old kprobes/tracefs events implementation on Linux.

Note that we send up events on changed [user/group] real id, effective id, *saved id, fs id*. The last two (saved/fs) we don't currently send to ECS, they're not in the schema (saved is sent to ECS in the new wide effect model, fs isn't sent at all, old or new event model). 

The existing kprobes/tracefs implementation however, sends a uid/gid change event for every invocation of `proc_id_connector` when passed the `PROC_EVENT_UID` or `PROC_EVENT_GID` parameters. It's called [from here](https://elixir.bootlin.com/linux/v5.9.9/source/kernel/cred.c#L497) in `commit_creds`:


```c
	/* send notifications */
	if (!uid_eq(new->uid,   old->uid)  ||
	    !uid_eq(new->euid,  old->euid) ||
	    !uid_eq(new->suid,  old->suid) ||
	    !uid_eq(new->fsuid, old->fsuid))
		proc_id_connector(task, PROC_EVENT_UID);

	if (!gid_eq(new->gid,   old->gid)  ||
	    !gid_eq(new->egid,  old->egid) ||
	    !gid_eq(new->sgid,  old->sgid) ||
	    !gid_eq(new->fsgid, old->fsgid))
		proc_id_connector(task, PROC_EVENT_GID);
```

This will result in a uid/gid change event being sent for a saved/fs uid/gid, even though that's not reported in the ECS schema. I just duplicate this behaviour in this PR (and will in endpoint) to maintain the existing behaviour, but it's a good thing to be aware of. @nicholasberlin Can you confirm my understanding is correct.

`commit_creds` has been in the kernel unchanged for well over a decade, so it should be a fairly stable thing to attach a kprobe to.
