### PR TITLE
EventProbe: aarch64 support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,6 +52,12 @@ add_subdirectory(non-GPL/TcLoader)
 # the header is being finalized.
 add_subdirectory(non-GPL/EventsTrace)
 
+# LibEbpfEventsTestLoader
+# Include an executable that loads the probe with different combination
+# of features, to have a quick feedback in case something breaks during
+# development.
+add_subdirectory(non-GPL/LibEbpfEventsTestLoader)
+
 # libeBPF
 add_custom_command(OUTPUT ${LIBEBPF_LIB}
                   WORKING_DIRECTORY ${TARGET_TMP_DIR}

--- a/GPL/EventProbe/File/Probe.bpf.c
+++ b/GPL/EventProbe/File/Probe.bpf.c
@@ -215,9 +215,10 @@ int BPF_KRETPROBE(kretprobe__do_filp_open, struct file *ret)
     return do_filp_open__exit(ret);
 }
 
-int rename_state__init()
+static int do_renameat2__enter()
 {
-    struct ebpf_events_state state = {.rename = {.step = RENAME_STATE_INIT}};
+    struct ebpf_events_state state = {};
+    state.rename.step = RENAME_STATE_INIT;
     ebpf_events_state__set(EBPF_EVENTS_STATE_RENAME, &state);
 
     u32 zero = 0;
@@ -231,28 +232,16 @@ out:
     return 0;
 }
 
-SEC("tracepoint/syscalls/sys_enter_rename")
-int tracepoint_sys_enter_rename(struct trace_event_raw_sys_enter *ctx)
-{
-    return rename_state__init();
-}
-
-SEC("tracepoint/syscalls/sys_enter_renameat")
-int tracepoint_sys_enter_renameat(struct trace_event_raw_sys_enter *ctx)
-{
-    return rename_state__init();
-}
-
-SEC("tracepoint/syscalls/sys_enter_renameat2")
-int tracepoint_sys_enter_renameat2(struct trace_event_raw_sys_enter *ctx)
-{
-    return rename_state__init();
-}
-
 SEC("fentry/do_renameat2")
 int BPF_PROG(fentry__do_renameat2)
 {
-    return rename_state__init();
+    return do_renameat2__enter();
+}
+
+SEC("kprobe/do_renameat2")
+int BPF_KPROBE(kprobe__do_renameat2)
+{
+    return do_renameat2__enter();
 }
 
 static int vfs_rename__enter(struct dentry *old_dentry, struct dentry *new_dentry)

--- a/GPL/EventProbe/File/Probe.bpf.c
+++ b/GPL/EventProbe/File/Probe.bpf.c
@@ -218,7 +218,7 @@ int BPF_KRETPROBE(kretprobe__do_filp_open, struct file *ret)
 static int do_renameat2__enter()
 {
     struct ebpf_events_state state = {};
-    state.rename.step = RENAME_STATE_INIT;
+    state.rename.step              = RENAME_STATE_INIT;
     ebpf_events_state__set(EBPF_EVENTS_STATE_RENAME, &state);
 
     u32 zero = 0;

--- a/GPL/EventProbe/File/Probe.bpf.c
+++ b/GPL/EventProbe/File/Probe.bpf.c
@@ -188,7 +188,7 @@ static int do_filp_open__exit(struct file *f)
         event->hdr.ts   = bpf_ktime_get_ns();
 
         struct task_struct *task = (struct task_struct *)bpf_get_current_task();
-        struct path p = BPF_CORE_READ(f, f_path);
+        struct path p            = BPF_CORE_READ(f, f_path);
         ebpf_resolve_path_to_string(event->path, &p, task);
         ebpf_pid_info__fill(&event->pids, task);
 

--- a/GPL/EventProbe/Network/Probe.bpf.c
+++ b/GPL/EventProbe/Network/Probe.bpf.c
@@ -28,6 +28,7 @@
 #include "Network.h"
 #include "State.h"
 
+// TODO: aarch64
 SEC("fexit/inet_csk_accept")
 int BPF_PROG(
     fexit__inet_csk_accept, struct sock *sk, int flags, int *err, bool kern, struct sock *ret)
@@ -72,6 +73,7 @@ out:
     return 0;
 }
 
+// TODO: aarch64
 SEC("fexit/tcp_v4_connect")
 int BPF_PROG(fexit__tcp_v4_connect, struct sock *sk, struct sockaddr *uaddr, int addr_len, int ret)
 {
@@ -87,7 +89,8 @@ int BPF_PROG(fexit__tcp_v6_connect, struct sock *sk, struct sockaddr *uaddr, int
 SEC("kprobe/tcp_v6_connect")
 int BPF_KPROBE(kprobe__tcp_v6_connect, struct sock *sk)
 {
-    struct ebpf_events_state state = {.tcp_v6_connect = {.sk = sk}};
+    struct ebpf_events_state state = {};
+    state.tcp_v6_connect.sk        = sk;
     ebpf_events_state__set(EBPF_EVENTS_STATE_TCP_V6_CONNECT, &state);
     return 0;
 }
@@ -104,6 +107,7 @@ int BPF_KRETPROBE(kretprobe__tcp_v6_connect, int ret)
     return tcp_connect(state->tcp_v6_connect.sk, ret);
 }
 
+// TODO: aarch64
 SEC("fentry/tcp_close")
 int BPF_PROG(fentry__tcp_close, struct sock *sk, long timeout)
 {

--- a/GPL/EventProbe/Process/Probe.bpf.c
+++ b/GPL/EventProbe/Process/Probe.bpf.c
@@ -107,6 +107,7 @@ out:
 // group_dead is the result of an atomic decrement and test operation on
 // task->signal->live, so is guaranteed to only be passed into taskstats_exit
 // as true once, which signifies the last thread in a thread group exiting.
+// TODO: aarch64
 SEC("fentry/taskstats_exit")
 int BPF_PROG(fentry__taskstats_exit, const struct task_struct *task, int group_dead)
 {
@@ -158,6 +159,7 @@ out:
     return 0;
 }
 
+// TODO: aarch64
 SEC("fentry/commit_creds")
 int BPF_PROG(fentry__commit_creds, struct cred *new)
 {

--- a/GPL/EventProbe/State.h
+++ b/GPL/EventProbe/State.h
@@ -24,7 +24,8 @@ enum ebpf_events_state_op {
     EBPF_EVENTS_STATE_UNKNOWN        = 0,
     EBPF_EVENTS_STATE_UNLINK         = 1,
     EBPF_EVENTS_STATE_RENAME         = 2,
-    EBPF_EVENTS_STATE_TCP_V6_CONNECT = 3,
+    EBPF_EVENTS_STATE_TCP_V4_CONNECT = 3,
+    EBPF_EVENTS_STATE_TCP_V6_CONNECT = 4,
 };
 
 struct ebpf_events_key {
@@ -48,7 +49,7 @@ struct ebpf_events_rename_state {
     struct vfsmount *mnt;
 };
 
-struct ebpf_events_tcp_v6_connect_state {
+struct ebpf_events_tcp_connect_state {
     struct sock *sk;
 };
 
@@ -56,7 +57,8 @@ struct ebpf_events_state {
     union {
         struct ebpf_events_unlink_state unlink;
         struct ebpf_events_rename_state rename;
-        struct ebpf_events_tcp_v6_connect_state tcp_v6_connect;
+        struct ebpf_events_tcp_connect_state tcp_v4_connect;
+        struct ebpf_events_tcp_connect_state tcp_v6_connect;
     };
 };
 

--- a/GPL/EventProbe/State.h
+++ b/GPL/EventProbe/State.h
@@ -34,6 +34,7 @@ struct ebpf_events_key {
 
 struct ebpf_events_unlink_state {
     struct vfsmount *mnt;
+    struct dentry de;
 };
 
 enum ebpf_events_rename_state_step {

--- a/non-GPL/EventsTrace/EventsTrace.c
+++ b/non-GPL/EventsTrace/EventsTrace.c
@@ -58,8 +58,8 @@ static const struct argp_option opts[] = {
      "Whether or not to consider network connection attempted events", 1},
     {"net-conn-closed", EBPF_EVENT_NETWORK_CONNECTION_CLOSED, NULL, false,
      "Whether or not to consider network connection closed events", 1},
-    {"set-bpf-tramp", EBPF_FEATURE_BPF_TRAMP, NULL, false,
-     "Set feature supported: bpf trampoline", 2},
+    {"set-bpf-tramp", EBPF_FEATURE_BPF_TRAMP, NULL, false, "Set feature supported: bpf trampoline",
+     2},
     {},
 };
 

--- a/non-GPL/EventsTrace/EventsTrace.c
+++ b/non-GPL/EventsTrace/EventsTrace.c
@@ -535,7 +535,11 @@ int main(int argc, char **argv)
     if (err)
         goto cleanup;
 
-    err = ebpf_event_ctx__new(&ctx, event_ctx_callback, g_features_env, g_events_env);
+    struct ebpf_event_ctx_opts opts = {
+        .events   = g_events_env,
+        .features = g_features_env,
+    };
+    err = ebpf_event_ctx__new(&ctx, event_ctx_callback, opts);
     if (err < 0) {
         fprintf(stderr, "Could not create event context: %d %s\n", err, strerror(-err));
         goto cleanup;

--- a/non-GPL/EventsTrace/EventsTrace.c
+++ b/non-GPL/EventsTrace/EventsTrace.c
@@ -58,10 +58,13 @@ static const struct argp_option opts[] = {
      "Whether or not to consider network connection attempted events", 1},
     {"net-conn-closed", EBPF_EVENT_NETWORK_CONNECTION_CLOSED, NULL, false,
      "Whether or not to consider network connection closed events", 1},
+    {"set-bpf-tramp", EBPF_FEATURE_BPF_TRAMP, NULL, false,
+     "Set feature supported: bpf trampoline", 2},
     {},
 };
 
 uint64_t g_events_env = 0;
+uint64_t g_features_env = 0;
 
 static error_t parse_arg(int key, char *arg, struct argp_state *state)
 {
@@ -82,6 +85,9 @@ static error_t parse_arg(int key, char *arg, struct argp_state *state)
     case EBPF_EVENT_NETWORK_CONNECTION_ATTEMPTED:
     case EBPF_EVENT_NETWORK_CONNECTION_CLOSED:
         g_events_env |= key;
+        break;
+    case EBPF_FEATURE_BPF_TRAMP:
+        g_features_env |= key;
         break;
     case ARGP_KEY_ARG:
         argp_usage(state);
@@ -529,9 +535,7 @@ int main(int argc, char **argv)
     if (err)
         goto cleanup;
 
-    uint64_t features = EBPF_KERNEL_FEATURE_BPF;
-    uint64_t events   = g_events_env;
-    err               = ebpf_event_ctx__new(&ctx, event_ctx_callback, features, events);
+    err = ebpf_event_ctx__new(&ctx, event_ctx_callback, g_features_env, g_events_env);
     if (err < 0) {
         fprintf(stderr, "Could not create event context: %d %s\n", err, strerror(-err));
         goto cleanup;

--- a/non-GPL/EventsTrace/EventsTrace.c
+++ b/non-GPL/EventsTrace/EventsTrace.c
@@ -63,7 +63,7 @@ static const struct argp_option opts[] = {
     {},
 };
 
-uint64_t g_events_env = 0;
+uint64_t g_events_env   = 0;
 uint64_t g_features_env = 0;
 
 static error_t parse_arg(int key, char *arg, struct argp_state *state)

--- a/non-GPL/LibEbpfEvents/LibEbpfEvents.c
+++ b/non-GPL/LibEbpfEvents/LibEbpfEvents.c
@@ -208,9 +208,6 @@ static inline int probe_set_autoload(struct btf *btf, struct EventProbe_bpf *obj
         err = err ?: bpf_program__set_autoload(obj->progs.kretprobe__do_filp_open, false);
         err = err ?: bpf_program__set_autoload(obj->progs.kprobe__vfs_rename, false);
         err = err ?: bpf_program__set_autoload(obj->progs.kretprobe__vfs_rename, false);
-        err = err ?: bpf_program__set_autoload(obj->progs.kprobe__tcp_v6_connect, false);
-        err = err ?: bpf_program__set_autoload(obj->progs.kretprobe__tcp_v6_connect, false);
-        err = err ?: bpf_program__set_autoload(obj->progs.kprobe__do_renameat2, false);
         err = err ?: bpf_program__set_autoload(obj->progs.kprobe__taskstats_exit, false);
         err = err ?: bpf_program__set_autoload(obj->progs.kprobe__commit_creds, false);
         err = err ?: bpf_program__set_autoload(obj->progs.kretprobe__inet_csk_accept, false);
@@ -224,8 +221,6 @@ static inline int probe_set_autoload(struct btf *btf, struct EventProbe_bpf *obj
         err = err ?: bpf_program__set_autoload(obj->progs.fexit__do_filp_open, false);
         err = err ?: bpf_program__set_autoload(obj->progs.fentry__vfs_rename, false);
         err = err ?: bpf_program__set_autoload(obj->progs.fexit__vfs_rename, false);
-        err = err ?: bpf_program__set_autoload(obj->progs.fentry__do_renameat2, false);
-        err = err ?: bpf_program__set_autoload(obj->progs.fexit__tcp_v6_connect, false);
         err = err ?: bpf_program__set_autoload(obj->progs.fentry__taskstats_exit, false);
         err = err ?: bpf_program__set_autoload(obj->progs.fentry__commit_creds, false);
         err = err ?: bpf_program__set_autoload(obj->progs.fexit__inet_csk_accept, false);

--- a/non-GPL/LibEbpfEvents/LibEbpfEvents.c
+++ b/non-GPL/LibEbpfEvents/LibEbpfEvents.c
@@ -215,6 +215,8 @@ static inline int probe_set_autoload(struct btf *btf, struct EventProbe_bpf *obj
         err = err ?: bpf_program__set_autoload(obj->progs.tracepoint_sys_enter_rename, false);
         err = err ?: bpf_program__set_autoload(obj->progs.tracepoint_sys_enter_renameat, false);
         err = err ?: bpf_program__set_autoload(obj->progs.tracepoint_sys_enter_renameat2, false);
+        err = err ?: bpf_program__set_autoload(obj->progs.kprobe__taskstats_exit, false);
+        err = err ?: bpf_program__set_autoload(obj->progs.kprobe__commit_creds, false);
     } else {
         err = err ?: bpf_program__set_autoload(obj->progs.fentry__do_unlinkat, false);
         err = err ?: bpf_program__set_autoload(obj->progs.fentry__mnt_want_write, false);
@@ -224,6 +226,8 @@ static inline int probe_set_autoload(struct btf *btf, struct EventProbe_bpf *obj
         err = err ?: bpf_program__set_autoload(obj->progs.fexit__vfs_rename, false);
         err = err ?: bpf_program__set_autoload(obj->progs.fentry__do_renameat2, false);
         err = err ?: bpf_program__set_autoload(obj->progs.fexit__tcp_v6_connect, false);
+        err = err ?: bpf_program__set_autoload(obj->progs.fentry__taskstats_exit, false);
+        err = err ?: bpf_program__set_autoload(obj->progs.fentry__commit_creds, false);
     }
 
     return err;

--- a/non-GPL/LibEbpfEvents/LibEbpfEvents.c
+++ b/non-GPL/LibEbpfEvents/LibEbpfEvents.c
@@ -178,18 +178,16 @@ static inline int probe_set_autoload(struct btf *btf, struct EventProbe_bpf *obj
     int err            = 0;
     bool has_bpf_tramp = features & EBPF_FEATURE_BPF_TRAMP;
 
-    // rename syscall tracepoints and do_renameat2 are mutually exclusive.
-    // disable auto-loading of tracepoints if `do_renameat2` exists in BTF and
+    // do_renameat2 kprobe and fentry probe are mutually exclusive.
+    // disable auto-loading of kprobe if `do_renameat2` exists in BTF and
     // if bpf trampolines are supported on the current arch, and vice-versa.
     if (has_bpf_tramp && BTF_FUNC_EXISTS(btf, do_renameat2)) {
-        err = err ?: bpf_program__set_autoload(obj->progs.tracepoint_sys_enter_rename, false);
-        err = err ?: bpf_program__set_autoload(obj->progs.tracepoint_sys_enter_renameat, false);
-        err = err ?: bpf_program__set_autoload(obj->progs.tracepoint_sys_enter_renameat2, false);
+        err = err ?: bpf_program__set_autoload(obj->progs.kprobe__do_renameat2, false);
     } else {
         err = err ?: bpf_program__set_autoload(obj->progs.fentry__do_renameat2, false);
     }
 
-    // tcp_v6_connect kprobes and fentry probes are mutually exclusive.
+    // tcp_v6_connect kprobes and fexit probe are mutually exclusive.
     // disable auto-loading of kprobes if `tcp_v6_connect` exists in BTF and
     // if bpf trampolines are supported on the current arch, and vice-versa.
     if (has_bpf_tramp && BTF_FUNC_EXISTS(btf, tcp_v6_connect)) {
@@ -212,9 +210,7 @@ static inline int probe_set_autoload(struct btf *btf, struct EventProbe_bpf *obj
         err = err ?: bpf_program__set_autoload(obj->progs.kretprobe__vfs_rename, false);
         err = err ?: bpf_program__set_autoload(obj->progs.kprobe__tcp_v6_connect, false);
         err = err ?: bpf_program__set_autoload(obj->progs.kretprobe__tcp_v6_connect, false);
-        err = err ?: bpf_program__set_autoload(obj->progs.tracepoint_sys_enter_rename, false);
-        err = err ?: bpf_program__set_autoload(obj->progs.tracepoint_sys_enter_renameat, false);
-        err = err ?: bpf_program__set_autoload(obj->progs.tracepoint_sys_enter_renameat2, false);
+        err = err ?: bpf_program__set_autoload(obj->progs.kprobe__do_renameat2, false);
         err = err ?: bpf_program__set_autoload(obj->progs.kprobe__taskstats_exit, false);
         err = err ?: bpf_program__set_autoload(obj->progs.kprobe__commit_creds, false);
         err = err ?: bpf_program__set_autoload(obj->progs.kretprobe__inet_csk_accept, false);

--- a/non-GPL/LibEbpfEvents/LibEbpfEvents.c
+++ b/non-GPL/LibEbpfEvents/LibEbpfEvents.c
@@ -217,6 +217,10 @@ static inline int probe_set_autoload(struct btf *btf, struct EventProbe_bpf *obj
         err = err ?: bpf_program__set_autoload(obj->progs.tracepoint_sys_enter_renameat2, false);
         err = err ?: bpf_program__set_autoload(obj->progs.kprobe__taskstats_exit, false);
         err = err ?: bpf_program__set_autoload(obj->progs.kprobe__commit_creds, false);
+        err = err ?: bpf_program__set_autoload(obj->progs.kretprobe__inet_csk_accept, false);
+        err = err ?: bpf_program__set_autoload(obj->progs.kprobe__tcp_v4_connect, false);
+        err = err ?: bpf_program__set_autoload(obj->progs.kretprobe__tcp_v4_connect, false);
+        err = err ?: bpf_program__set_autoload(obj->progs.kprobe__tcp_close, false);
     } else {
         err = err ?: bpf_program__set_autoload(obj->progs.fentry__do_unlinkat, false);
         err = err ?: bpf_program__set_autoload(obj->progs.fentry__mnt_want_write, false);
@@ -228,6 +232,9 @@ static inline int probe_set_autoload(struct btf *btf, struct EventProbe_bpf *obj
         err = err ?: bpf_program__set_autoload(obj->progs.fexit__tcp_v6_connect, false);
         err = err ?: bpf_program__set_autoload(obj->progs.fentry__taskstats_exit, false);
         err = err ?: bpf_program__set_autoload(obj->progs.fentry__commit_creds, false);
+        err = err ?: bpf_program__set_autoload(obj->progs.fexit__inet_csk_accept, false);
+        err = err ?: bpf_program__set_autoload(obj->progs.fexit__tcp_v4_connect, false);
+        err = err ?: bpf_program__set_autoload(obj->progs.fentry__tcp_close, false);
     }
 
     return err;

--- a/non-GPL/LibEbpfEvents/LibEbpfEvents.h
+++ b/non-GPL/LibEbpfEvents/LibEbpfEvents.h
@@ -14,10 +14,8 @@
 
 #include "EbpfEventProto.h"
 
-enum ebpf_kernel_features {
-    EBPF_KERNEL_FEATURE_BPF     = (1 << 0),
-    EBPF_KERNEL_FEATURE_RINGBUF = (1 << 1),
-    EBPF_KERNEL_FEATURE_BTF     = (1 << 2),
+enum ebpf_kernel_feature {
+    EBPF_FEATURE_BPF_TRAMP = (1 << 0),
 };
 
 /* Opaque context */

--- a/non-GPL/LibEbpfEvents/LibEbpfEvents.h
+++ b/non-GPL/LibEbpfEvents/LibEbpfEvents.h
@@ -10,6 +10,7 @@
 #ifndef EBPF_EVENTS_H_
 #define EBPF_EVENTS_H_
 
+#include <stdbool.h>
 #include <stddef.h>
 
 #include "EbpfEventProto.h"
@@ -23,6 +24,12 @@ struct ebpf_event_ctx;
 
 typedef int (*ebpf_event_handler_fn)(struct ebpf_event_header *);
 
+struct ebpf_event_ctx_opts {
+    uint64_t events;
+    uint64_t features;
+    bool features_autodetect;
+};
+
 /* Allocates a new context based on requested events and capabilities.
  *
  * If ctx is NULL, the function returns right after loading and attaching the
@@ -34,8 +41,7 @@ typedef int (*ebpf_event_handler_fn)(struct ebpf_event_header *);
  */
 int ebpf_event_ctx__new(struct ebpf_event_ctx **ctx,
                         ebpf_event_handler_fn cb,
-                        uint64_t features,
-                        uint64_t events);
+                        struct ebpf_event_ctx_opts opts);
 
 /* Consumes as many events as possible from the event context and returns the
  * number consumed.

--- a/non-GPL/LibEbpfEventsTestLoader/CMakeLists.txt
+++ b/non-GPL/LibEbpfEventsTestLoader/CMakeLists.txt
@@ -1,0 +1,17 @@
+# SPDX-License-Identifier: LicenseRef-Elastic-License-2.0
+
+# Copyright 2021 Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License 2.0;
+# you may not use this file except in compliance with the Elastic License 2.0.
+
+add_executable(LibEbpfEventsTestLoader LibEbpfEventsTestLoader.c)
+add_dependencies(LibEbpfEventsTestLoader LibEbpfEvents EventProbe_skeleton libbpf libelf)
+target_link_libraries(LibEbpfEventsTestLoader LibEbpfEvents ${LIBBPF_LIB} ${LIBELF_LIB} -lz)
+
+target_include_directories(LibEbpfEventsTestLoader PRIVATE
+    "${LIBBPF_TARGET_INCLUDE_DIR}"
+    "${LIBBPF_UAPI_INCLUDE_DIR}"
+    "${LIBBPF_INCLUDE_DIR}"
+    "${CMAKE_SOURCE_DIR}/GPL/Events"
+    "${TARGET_INCLUDE_DIR}"
+)

--- a/non-GPL/LibEbpfEventsTestLoader/LibEbpfEventsTestLoader.c
+++ b/non-GPL/LibEbpfEventsTestLoader/LibEbpfEventsTestLoader.c
@@ -7,32 +7,37 @@
  * License 2.0.
  */
 
+#include <stdbool.h>
 #include <stdio.h>
 
 #include <LibEbpfEvents.h>
 
-static void print_features(uint64_t features)
+static void print_features(uint64_t features, bool autodetect)
 {
     printf("features: ");
     if (features & EBPF_FEATURE_BPF_TRAMP)
         printf("bpf_tramp,");
-    printf("\n");
+    printf(" (autodetect=%s) \n", autodetect ? "true" : "false");
 }
 
-static void test_with(uint64_t features)
+static void test_with(uint64_t features, bool autodetect)
 {
-    if (ebpf_event_ctx__new(NULL, NULL, features, 0)) {
+    struct ebpf_event_ctx_opts opts = {};
+    opts.features                   = features;
+    opts.features_autodetect        = autodetect;
+    if (ebpf_event_ctx__new(NULL, NULL, opts)) {
         printf("probe could not load with ");
         goto out;
     }
     printf("probe did load successfully with ");
 out:
-    print_features(features);
+    print_features(features, autodetect);
 }
 
 int main(int argc, char **argv)
 {
-    test_with(EBPF_FEATURE_BPF_TRAMP);
-    test_with(0);
+    test_with(EBPF_FEATURE_BPF_TRAMP, false);
+    test_with(0, false);
+    test_with(0, true);
     return 0;
 }

--- a/non-GPL/LibEbpfEventsTestLoader/LibEbpfEventsTestLoader.c
+++ b/non-GPL/LibEbpfEventsTestLoader/LibEbpfEventsTestLoader.c
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: Elastic-2.0
+
+/*
+ * Copyright 2021 Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under
+ * one or more contributor license agreements. Licensed under the Elastic
+ * License 2.0; you may not use this file except in compliance with the Elastic
+ * License 2.0.
+ */
+
+#include <stdio.h>
+
+#include <LibEbpfEvents.h>
+
+static void print_features(uint64_t features)
+{
+    printf("features: ");
+    if (features & EBPF_FEATURE_BPF_TRAMP)
+        printf("bpf_tramp,");
+    printf("\n");
+}
+
+static void test_with(uint64_t features)
+{
+    if (ebpf_event_ctx__new(NULL, NULL, features, 0)) {
+        printf("probe could not load with ");
+        goto out;
+    }
+    printf("probe did load successfully with ");
+out:
+    print_features(features);
+}
+
+int main(int argc, char **argv)
+{
+    test_with(EBPF_FEATURE_BPF_TRAMP);
+    test_with(0);
+    return 0;
+}


### PR DESCRIPTION
1. finally use `features` to make decisions during probe load-link
2. add a small utility binary `LibEbpfEventsTestLoader` which tries to load the probe with every combination of features for a fast feedback during development
3. add the possibility to specify features in `EventsTrace`
4. adds aarch64 support
