### PR TITLE
EventProbe: delete state right after sending the event

### DIFF
--- a/GPL/EventProbe/EbpfEventProto.h
+++ b/GPL/EventProbe/EbpfEventProto.h
@@ -19,6 +19,8 @@
 // fits in PATH_MAX
 #define PATH_MAX_BUF PATH_MAX * 2
 
+#define TASK_COMM_LEN 16
+
 #ifndef __KERNEL__
 #include <stdint.h>
 #else
@@ -74,7 +76,7 @@ struct ebpf_file_delete_event {
     struct ebpf_pid_info pids;
     char path[PATH_MAX_BUF];
     uint32_t mntns;
-    char comm[16]; // TASK_COMM_LEN
+    char comm[TASK_COMM_LEN];
 } __attribute__((packed));
 
 struct ebpf_file_create_event {
@@ -82,7 +84,7 @@ struct ebpf_file_create_event {
     struct ebpf_pid_info pids;
     char path[PATH_MAX_BUF];
     uint32_t mntns;
-    char comm[16]; // TASK_COMM_LEN
+    char comm[TASK_COMM_LEN];
 } __attribute__((packed));
 
 struct ebpf_file_rename_event {
@@ -91,7 +93,7 @@ struct ebpf_file_rename_event {
     char old_path[PATH_MAX_BUF];
     char new_path[PATH_MAX_BUF];
     uint32_t mntns;
-    char comm[16]; // TASK_COMM_LEN
+    char comm[TASK_COMM_LEN];
 } __attribute__((packed));
 
 struct ebpf_process_fork_event {
@@ -170,7 +172,7 @@ struct ebpf_net_event {
     struct ebpf_event_header hdr;
     struct ebpf_pid_info pids;
     struct ebpf_net_info net;
-    char comm[16]; // TASK_COMM_LEN
+    char comm[TASK_COMM_LEN];
 } __attribute__((packed));
 
 #endif // EBPF_EVENTPROBE_EBPFEVENTPROTO_H

--- a/GPL/EventProbe/EbpfEventProto.h
+++ b/GPL/EventProbe/EbpfEventProto.h
@@ -73,12 +73,16 @@ struct ebpf_file_delete_event {
     struct ebpf_event_header hdr;
     struct ebpf_pid_info pids;
     char path[PATH_MAX_BUF];
+    uint32_t mntns;
+    char comm[16]; // TASK_COMM_LEN
 } __attribute__((packed));
 
 struct ebpf_file_create_event {
     struct ebpf_event_header hdr;
     struct ebpf_pid_info pids;
     char path[PATH_MAX_BUF];
+    uint32_t mntns;
+    char comm[16]; // TASK_COMM_LEN
 } __attribute__((packed));
 
 struct ebpf_file_rename_event {
@@ -86,6 +90,8 @@ struct ebpf_file_rename_event {
     struct ebpf_pid_info pids;
     char old_path[PATH_MAX_BUF];
     char new_path[PATH_MAX_BUF];
+    uint32_t mntns;
+    char comm[16]; // TASK_COMM_LEN
 } __attribute__((packed));
 
 struct ebpf_process_fork_event {

--- a/GPL/EventProbe/File/Probe.bpf.c
+++ b/GPL/EventProbe/File/Probe.bpf.c
@@ -121,7 +121,7 @@ static int vfs_unlink__exit(int ret, struct dentry *de)
     p.mnt    = state->unlink.mnt;
     ebpf_resolve_path_to_string(event->path, &p, task);
     event->mntns = mntns(task);
-    bpf_get_current_comm(event->comm, 16);
+    bpf_get_current_comm(event->comm, TASK_COMM_LEN);
 
     bpf_ringbuf_submit(event, 0);
 
@@ -205,7 +205,7 @@ static int do_filp_open__exit(struct file *f)
         ebpf_resolve_path_to_string(event->path, &p, task);
         ebpf_pid_info__fill(&event->pids, task);
         event->mntns = mntns(task);
-        bpf_get_current_comm(event->comm, 16);
+        bpf_get_current_comm(event->comm, TASK_COMM_LEN);
 
         bpf_ringbuf_submit(event, 0);
     }
@@ -366,7 +366,7 @@ static int vfs_rename__exit(int ret)
     bpf_probe_read_kernel_str(event->old_path, PATH_MAX_BUF, ss->rename.old_path);
     bpf_probe_read_kernel_str(event->new_path, PATH_MAX_BUF, ss->rename.new_path);
     event->mntns = mntns(task);
-    bpf_get_current_comm(event->comm, 16);
+    bpf_get_current_comm(event->comm, TASK_COMM_LEN);
 
     bpf_ringbuf_submit(event, 0);
 

--- a/GPL/EventProbe/File/Probe.bpf.c
+++ b/GPL/EventProbe/File/Probe.bpf.c
@@ -124,6 +124,10 @@ static int vfs_unlink__exit(int ret, struct dentry *de)
     bpf_get_current_comm(event->comm, 16);
 
     bpf_ringbuf_submit(event, 0);
+
+    // Certain filesystems (eg. overlayfs) call vfs_unlink twice during the same
+    // execution context.
+    // In order to not emit a second event, delete the state explicitly. 
     ebpf_events_state__del(EBPF_EVENTS_STATE_UNLINK);
 
 out:
@@ -365,6 +369,10 @@ static int vfs_rename__exit(int ret)
     bpf_get_current_comm(event->comm, 16);
 
     bpf_ringbuf_submit(event, 0);
+
+    // Certain filesystems (eg. overlayfs) call vfs_rename twice during the same
+    // execution context.
+    // In order to not emit a second event, delete the state explicitly. 
     ebpf_events_state__del(EBPF_EVENTS_STATE_RENAME);
 
 out:

--- a/GPL/EventProbe/Network/Network.h
+++ b/GPL/EventProbe/Network/Network.h
@@ -97,7 +97,7 @@ static int ebpf_network_event__fill(struct ebpf_net_event *evt, struct sock *sk)
 
     struct task_struct *task = (struct task_struct *)bpf_get_current_task();
     ebpf_pid_info__fill(&evt->pids, task);
-    bpf_get_current_comm(evt->comm, 16);
+    bpf_get_current_comm(evt->comm, TASK_COMM_LEN);
     evt->hdr.ts = bpf_ktime_get_ns();
 
 out:

--- a/GPL/EventProbe/State.h
+++ b/GPL/EventProbe/State.h
@@ -89,6 +89,12 @@ static long ebpf_events_state__set(enum ebpf_events_state_op op, struct ebpf_eve
     return bpf_map_update_elem(&elastic_ebpf_events_state, &key, state, BPF_ANY);
 }
 
+static long ebpf_events_state__del(enum ebpf_events_state_op op)
+{
+    struct ebpf_events_key key = ebpf_events_state__key(op);
+    return bpf_map_delete_elem(&elastic_ebpf_events_state, &key);
+}
+
 #define PATH_MAX 4096
 #define BUF PATH_MAX * 2
 

--- a/non-GPL/EventsTrace/EventsTrace.c
+++ b/non-GPL/EventsTrace/EventsTrace.c
@@ -261,6 +261,12 @@ static void out_file_delete(struct ebpf_file_delete_event *evt)
     out_comma();
 
     out_string("path", evt->path);
+    out_comma();
+
+    out_int("mount_namespace", evt->mntns);
+    out_comma();
+
+    out_string("comm", (const char *)&evt->comm);
 
     out_object_end();
     out_newline();
@@ -276,6 +282,12 @@ static void out_file_create(struct ebpf_file_create_event *evt)
     out_comma();
 
     out_string("path", evt->path);
+    out_comma();
+
+    out_int("mount_namespace", evt->mntns);
+    out_comma();
+
+    out_string("comm", (const char *)&evt->comm);
 
     out_object_end();
     out_newline();
@@ -294,6 +306,12 @@ static void out_file_rename(struct ebpf_file_rename_event *evt)
     out_comma();
 
     out_string("new_path", evt->new_path);
+    out_comma();
+
+    out_int("mount_namespace", evt->mntns);
+    out_comma();
+
+    out_string("comm", (const char *)&evt->comm);
 
     out_object_end();
     out_newline();


### PR DESCRIPTION
I investigated a bit and seems that the issue is caused by how [overlayfs](https://www.kernel.org/doc/Documentation/filesystems/overlayfs.txt) work. 

I reproduced with
```
~ /tmp sudo mount -t overlay overlay -olowerdir=/tmp/lower,upperdir=/tmp/upper,workdir=/tmp/work /tmp/merged
~ /tmp/merged touch test
~ /tmp/merged rm test

{"event_type":"FILE_DELETE",..,"path":"./test","mount_namespace":4026531840,"comm":"rm"}
{"event_type":"FILE_DELETE",..,"path":"./test","mount_namespace":4026531840,"comm":"rm"}
```
```
~ lsns -t mnt
        NS TYPE NPROCS   PID USER COMMAND
4026531840 mnt     121 24401 matt /usr/lib/systemd/systemd --user
4026533394 mnt       1 53972 matt podman
```

The only solution I could find is to explicitly delete the state so the event relative to the second `vfs_*` call gets dropped.

Closes https://github.com/elastic/ebpf/issues/73