### PR TITLE
Adds external/supplementary user to exec events

### DIFF
--- a/GPL/EventProbe/EbpfEventProto.h
+++ b/GPL/EventProbe/EbpfEventProto.h
@@ -11,6 +11,8 @@
 #define EBPF_EVENTPROBE_EBPFEVENTPROTO_H
 
 #define ARGV_MAX 8192 // See issue #43, quite possibly too small
+#define ENVC_MAX 100 // TODO: Set better value
+#define ENVV_MAX 32768 // TODO: Set better value
 
 #define PATH_MAX 4096
 // When computing the path we need to allocate twice the size of PATH_MAX
@@ -113,6 +115,7 @@ struct ebpf_process_exec_event {
     char filename[PATH_MAX];
     char cwd[PATH_MAX];
     char argv[ARGV_MAX];
+    char envv[ENVV_MAX];
     char pids_ss_cgroup_path[PATH_MAX];
 } __attribute__((packed));
 

--- a/GPL/EventProbe/Process/Probe.bpf.c
+++ b/GPL/EventProbe/Process/Probe.bpf.c
@@ -77,6 +77,7 @@ int BPF_PROG(sched_process_exec,
     ebpf_cred_info__fill(&event->creds, task);
     ebpf_ctty__fill(&event->ctty, task);
     ebpf_argv__fill(event->argv, sizeof(event->argv), task);
+    ebpf_envv__fill(event->envv, sizeof(event->envv), task, binprm);
     ebpf_resolve_path_to_string(event->cwd, &task->fs->pwd, task);
     ebpf_resolve_pids_ss_cgroup_path_to_string(event->pids_ss_cgroup_path, task);
     bpf_probe_read_kernel_str(event->filename, sizeof(event->filename), binprm->filename);

--- a/non-GPL/EventsTrace/EventsTrace.c
+++ b/non-GPL/EventsTrace/EventsTrace.c
@@ -252,6 +252,16 @@ static void out_cred_info(const char *name, struct ebpf_cred_info *cred_info)
     out_object_end();
 }
 
+static void out_external_user(const char *name, char *buf)
+{
+    if (buf[0] == '\0') {
+        printf("\"%s\":\"\"", name);
+        return;
+    }
+
+    out_string(name, &buf[9]);
+}
+
 static void out_argv(const char *name, char *buf, size_t buf_size)
 {
     // Buf is the argv array, with each argument delimited by a '\0', rework
@@ -383,6 +393,9 @@ static void out_process_exec(struct ebpf_process_exec_event *evt)
     out_comma();
 
     out_argv("argv", evt->argv, sizeof(evt->argv));
+    out_comma();
+
+    out_external_user("k8s_user", evt->envv);
 
     out_object_end();
     out_newline();


### PR DESCRIPTION
This adds the value of an environment variable, currently
"K8S_USER" but subject to change, to exec events if exists. This
involves lots of string comparisons, so it eats up a lot of
instructions. The number of environment variables that are able to be
checked is currently limited to 100. The number of instructions is also
highly dependent on the name to be searched. So when deciding on the final
variable name to check, this must be taken into account.

If possible, the admission controller should try to set the variable as
one of the first vars. If we can lower the number of vars to check, we
can gain back some headroom to either use a more descriptive name or add
more functionality to the exec hook.

This PR is just for feedback and discussing implementation details and limitations. The requirements for the feature are not complete.