### PR TITLE
Cleanup CMake usage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,16 +11,6 @@ project(ebpf)
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules")
 
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -g -O2 -Wall -fPIC")
-set(TARGET_DIR_DEFAULT "${CMAKE_CURRENT_BINARY_DIR}/target")
-set(TARGET_DIR "${TARGET_DIR_DEFAULT}" CACHE STRING "Custom target directory")
-set(TARGET_TEST_DIR "${TARGET_DIR}/test")
-set(TARGET_INCLUDE_DIR "${TARGET_DIR}/include")
-set(TARGET_EBPF_DIR "${TARGET_DIR}/ebpf")
-
-file(MAKE_DIRECTORY ${TARGET_DIR})
-file(MAKE_DIRECTORY ${TARGET_INCLUDE_DIR})
-file(MAKE_DIRECTORY ${TARGET_EBPF_DIR})
-file(MAKE_DIRECTORY ${TARGET_TEST_DIR})
 
 include(ExternalProject)
 include(libelf)

--- a/GPL/Events/CMakeLists.txt
+++ b/GPL/Events/CMakeLists.txt
@@ -5,8 +5,6 @@
 # This software is dual-licensed under the BSD 2-Clause and GPL v2 licenses, you
 # may choose either one of them if you use this software.
 
-# BPF program
-
 if (CMAKE_BUILD_TYPE STREQUAL Debug OR ENABLE_BPF_PRINTK)
     set(BPF_DEBUG_TRACE 1)
 else()
@@ -24,32 +22,25 @@ set(EVENTS_PROBE_CFLAGS
                 -D__TARGET_ARCH_${ARCH_TRUNC}
                 -D__${ARCH}__
                 -I${LIBBPF_TARGET_INCLUDE_DIR}
-                -I${TARGET_INCLUDE_DIR}
-                -I${LIBBPF_UAPI_INCLUDE_DIR}
-                -I${LIBBPF_INCLUDE_DIR}
                 -I${VMLINUX_INCLUDE_DIR}
                 -I${EVENTS_PROBE_SOURCE_DIR}
                 -fno-ident)
 
-configure_file(EbpfEventProto.h ${TARGET_INCLUDE_DIR} COPYONLY)
 set(EVENTS_PROBE_SOURCES ${EVENTS_PROBE_SOURCE_DIR}/EventProbe.bpf.c)
 file(GLOB EVENTS_PROBE_INCLUDES "${EVENTS_PROBE_SOURCE_DIR}/*.h")
-message(STATUS "Including: ${EVENTS_PROBE_INCLUDES}")
 
-set(EVENTS_PROBE_BPF_OUTPUT ${TARGET_EBPF_DIR}/EventProbe.bpf.o)
+set(EVENTS_PROBE_BPF_OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/EventProbe.bpf.o)
 add_custom_command(OUTPUT ${EVENTS_PROBE_BPF_OUTPUT}
                   COMMAND ${EBPF_EXTERNAL_ENV_FLAGS} ${CLANG} ${EVENTS_PROBE_CFLAGS} -c ${EVENTS_PROBE_SOURCES} -o ${EVENTS_PROBE_BPF_OUTPUT}
                   DEPENDS libbpf
-                  DEPFILE ${EVENTS_PROBE_DEPFILE}
-                  COMMENT "[bpf] building ${EVENTS_PROBE_BPF_OUTPUT}")
+                  DEPFILE ${EVENTS_PROBE_DEPFILE})
 
 add_custom_target(BPFEventProbe ALL DEPENDS ${EVENTS_PROBE_BPF_OUTPUT})
 
 if (NOT CMAKE_BUILD_TYPE STREQUAL Debug)
     add_custom_command(TARGET BPFEventProbe
         POST_BUILD
-        COMMAND ${LLVM_STRIP} -d -g -S ${EVENTS_PROBE_BPF_OUTPUT}
-        COMMENT "[bpf] stripping ${EVENTS_PROBE_BPF_OUTPUT}")
+        COMMAND ${LLVM_STRIP} -d -g -S ${EVENTS_PROBE_BPF_OUTPUT})
 endif()
 
 bpf_skeleton(EventProbe)

--- a/GPL/Events/PathResolver.h
+++ b/GPL/Events/PathResolver.h
@@ -243,22 +243,16 @@ static void ebpf_resolve_pids_ss_cgroup_path_to_string(char *buf, const struct t
      * can change kernel-to-kernel depending on the kconfig or possibly not be
      * enabled at all.
      */
-    // NOTE: This code is commented out to get this PR building and in a
-    // reviewable state as our toolchain currently uses LLVM 12, which doesn't
-    // support bpf_core_enum_value_exists. @stanek-michal is currently working
-    // on updating to LLVM 14. This will be removed when the toolchain is
-    // updated.
-    //
-    //    int cgrp_id;
-    //    if (bpf_core_enum_value_exists(enum cgroup_subsys_id, pids_cgrp_id)) {
-    //        cgrp_id = bpf_core_enum_value(enum cgroup_subsys_id, pids_cgrp_id);
-    //    } else {
-    //        /* Pids cgroup is not enabled on this kernel */
-    //        buf[0] = '\0';
-    //        return;
-    //    }
+    int cgrp_id;
+    if (bpf_core_enum_value_exists(enum cgroup_subsys_id, pids_cgrp_id)) {
+        cgrp_id = bpf_core_enum_value(enum cgroup_subsys_id, pids_cgrp_id);
+    } else {
+        /* Pids cgroup is not enabled on this kernel */
+        buf[0] = '\0';
+        return;
+    }
 
-    struct kernfs_node *kn = BPF_CORE_READ(task, cgroups, subsys[pids_cgrp_id], cgroup, kn);
+    struct kernfs_node *kn = BPF_CORE_READ(task, cgroups, subsys[cgrp_id], cgroup, kn);
     ebpf_resolve_kernfs_node_to_string(buf, kn);
 }
 

--- a/GPL/Events/PathResolver.h
+++ b/GPL/Events/PathResolver.h
@@ -243,16 +243,22 @@ static void ebpf_resolve_pids_ss_cgroup_path_to_string(char *buf, const struct t
      * can change kernel-to-kernel depending on the kconfig or possibly not be
      * enabled at all.
      */
-    int cgrp_id;
-    if (bpf_core_enum_value_exists(enum cgroup_subsys_id, pids_cgrp_id)) {
-        cgrp_id = bpf_core_enum_value(enum cgroup_subsys_id, pids_cgrp_id);
-    } else {
-        /* Pids cgroup is not enabled on this kernel */
-        buf[0] = '\0';
-        return;
-    }
+    // NOTE: This code is commented out to get this PR building and in a
+    // reviewable state as our toolchain currently uses LLVM 12, which doesn't
+    // support bpf_core_enum_value_exists. @stanek-michal is currently working
+    // on updating to LLVM 14. This will be removed when the toolchain is
+    // updated.
+    //
+    //    int cgrp_id;
+    //    if (bpf_core_enum_value_exists(enum cgroup_subsys_id, pids_cgrp_id)) {
+    //        cgrp_id = bpf_core_enum_value(enum cgroup_subsys_id, pids_cgrp_id);
+    //    } else {
+    //        /* Pids cgroup is not enabled on this kernel */
+    //        buf[0] = '\0';
+    //        return;
+    //    }
 
-    struct kernfs_node *kn = BPF_CORE_READ(task, cgroups, subsys[cgrp_id], cgroup, kn);
+    struct kernfs_node *kn = BPF_CORE_READ(task, cgroups, subsys[pids_cgrp_id], cgroup, kn);
     ebpf_resolve_kernfs_node_to_string(buf, kn);
 }
 

--- a/GPL/HostIsolation/CMakeLists.txt
+++ b/GPL/HostIsolation/CMakeLists.txt
@@ -4,5 +4,8 @@
 # or more contributor license agreements. Licensed under the Elastic License 2.0;
 # you may not use this file except in compliance with the Elastic License 2.0.
 
+set(HOSTISOLATION_EBPF_OBJECT_DIR "${CMAKE_CURRENT_BINARY_DIR}/ebpf-objects")
+file(MAKE_DIRECTORY ${HOSTISOLATION_EBPF_OBJECT_DIR})
+
 add_subdirectory(KprobeConnectHook)
 add_subdirectory(TcFilter)

--- a/GPL/HostIsolation/KprobeConnectHook/CMakeLists.txt
+++ b/GPL/HostIsolation/KprobeConnectHook/CMakeLists.txt
@@ -5,7 +5,6 @@
 # This software is dual-licensed under the BSD 2-Clause and GPL v2 licenses, you
 # may choose either one of them if you use this software.
 
-# BPF program
 set(KPROBECONNECTHOOK_CFLAGS
                         -g -O2
                         -target bpf
@@ -13,16 +12,15 @@ set(KPROBECONNECTHOOK_CFLAGS
                         -D__${ARCH}__
                         -I${LIBBPF_TARGET_INCLUDE_DIR}
                         -I${LIBBPF_UAPI_INCLUDE_DIR}
-                        -I${LIBBPF_INCLUDE_DIR}
                         -I${CMAKE_SOURCE_DIR}/non-GPL/Common
                         -fno-ident)
 
-set(KPROBECONNECTHOOK_BPF_OUTPUT ${TARGET_EBPF_DIR}/KprobeConnectHook.bpf.o)
+set(KPROBECONNECTHOOK_BPF_OUTPUT ${HOSTISOLATION_EBPF_OBJECT_DIR}/KprobeConnectHook.bpf.o)
 add_custom_command(OUTPUT ${KPROBECONNECTHOOK_BPF_OUTPUT}
                   COMMAND ${EBPF_EXTERNAL_ENV_FLAGS} ${CLANG} ${KPROBECONNECTHOOK_CFLAGS} -c ${CMAKE_CURRENT_SOURCE_DIR}/KprobeConnectHook.bpf.c -o ${KPROBECONNECTHOOK_BPF_OUTPUT}
                   COMMENT "Building ${KPROBECONNECTHOOK_BPF_OUTPUT}"
                   DEPENDS libbpf
                   IMPLICIT_DEPENDS C ${CMAKE_CURRENT_SOURCE_DIR}/KprobeConnectHook.bpf.c)
 
-add_custom_target(BPFKprobeConnectHook ALL DEPENDS ${TARGET_EBPF_DIR}/KprobeConnectHook.bpf.o)
+add_custom_target(BPFKprobeConnectHook ALL DEPENDS ${HOSTISOLATION_EBPF_OBJECT_DIR}/KprobeConnectHook.bpf.o)
 

--- a/GPL/HostIsolation/TcFilter/CMakeLists.txt
+++ b/GPL/HostIsolation/TcFilter/CMakeLists.txt
@@ -5,10 +5,10 @@
 # This software is dual-licensed under the BSD 2-Clause and GPL v2 licenses, you
 # may choose either one of them if you use this software.
 
-# BPF program
 set(TCFILTER_CFLAGS
                 -g -O2 -nostdinc -isystem ${NOSTDINC_INCLUDES}
                 -I${PROJECT_SOURCE_DIR}/contrib/kernel_hdrs
+                -I${LIBBPF_UAPI_INCLUDE_DIR}
                 -D__KERNEL__
                 -D__BPF_TRACING
                 -Wno-unused-value
@@ -22,7 +22,7 @@ set(TCFILTER_CFLAGS
                 -fno-ident)
 
 
-set(TCFILTER_BPF_OUTPUT ${TARGET_EBPF_DIR}/TcFilter.bpf.o)
+set(TCFILTER_BPF_OUTPUT ${HOSTISOLATION_EBPF_OBJECT_DIR}/TcFilter.bpf.o)
 add_custom_command(OUTPUT ${TCFILTER_BPF_OUTPUT}
                   COMMAND ${EBPF_EXTERNAL_ENV_FLAGS} ${CLANG} ${TCFILTER_CFLAGS} -emit-llvm -c ${CMAKE_CURRENT_SOURCE_DIR}/TcFilter.bpf.c -o - | ${LLC} -march=bpf -mcpu=v2 -filetype=obj -o  ${TCFILTER_BPF_OUTPUT}
                   COMMENT "Building  ${TCFILTER_BPF_OUTPUT}"
@@ -32,15 +32,13 @@ add_custom_target(BPFTcFilter ALL DEPENDS  ${TCFILTER_BPF_OUTPUT})
 
 # BPF_PROG_TEST_RUN gtests
 add_executable(BPFTcFilterTests BPFTcFilterTests.cpp ${GTEST_MAIN})
-set_target_properties(BPFTcFilterTests PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${TARGET_TEST_DIR})
-target_include_directories(BPFTcFilterTests PRIVATE
-    "${LIBBPF_TARGET_INCLUDE_DIR}"
+target_include_directories(BPFTcFilterTests
+    PRIVATE
     "${LIBBPF_UAPI_INCLUDE_DIR}"
-    "${LIBBPF_INCLUDE_DIR}"
     "${GTEST_INCLUDE}")
 
 add_dependencies(BPFTcFilterTests BPFTcFilter)
 
-target_link_libraries(BPFTcFilterTests ${LIBBPF_LIB} ${LIBELF_LIB} ${GTEST_LIB} -pthread -lz)
+target_link_libraries(BPFTcFilterTests libbpf ${GTEST_LIB} -pthread)
 add_dependencies(BPFTcFilterTests libbpf libelf gtest)
 

--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ build-debug:
 _internal-build:
 	mkdir -p ${BUILD_DIR}/
 	cmake ${EXTRA_CMAKE_FLAGS} ${CMAKE_FLAGS}
-	make -C${BUILD_DIR} -j$(shell nproc)
+	make VERBOSE=1 -C${BUILD_DIR} -j$(shell nproc)
 
 container:
 	docker build -t ${DOCKER_LOCAL_TAG} -f docker/Dockerfile.builder .

--- a/cmake/modules/BPF.cmake
+++ b/cmake/modules/BPF.cmake
@@ -11,7 +11,7 @@ set(LLC "llc")
 set(LLVM_STRIP "llvm-strip")
 set(BPFTOOL "bpftool")
 set(BTF_FILE "/sys/kernel/btf/vmlinux")
-option(USE_BUILTIN_VMLINUX "Whether or not to use the builtin vmlinux.h for building the BPF programs instead of trying to generate one from the system" True)
+option(USE_BUILTIN_VMLINUX "If true, use the builtin vmlinux.h for building BPF probes instead of generating one from system BTF" True)
 
 # Standard includes
 execute_process(COMMAND ${CLANG} -print-file-name=include
@@ -38,8 +38,8 @@ endif()
 
 # Skeleton generation
 macro(bpf_skeleton name)
-    set(_object_file_path ${TARGET_EBPF_DIR}/${name}.bpf.o)
-    set(_skeleton_file_path ${TARGET_INCLUDE_DIR}/${name}.skel.h)
+    set(_object_file_path ${CMAKE_CURRENT_BINARY_DIR}/${name}.bpf.o)
+    set(_skeleton_file_path ${CMAKE_CURRENT_BINARY_DIR}/${name}.skel.h)
     add_custom_target(
         ${name}_skeleton
         COMMAND ${BPFTOOL} gen skeleton ${_object_file_path} > ${_skeleton_file_path}

--- a/cmake/modules/BPF.cmake
+++ b/cmake/modules/BPF.cmake
@@ -11,7 +11,7 @@ set(LLC "llc")
 set(LLVM_STRIP "llvm-strip")
 set(BPFTOOL "bpftool")
 set(BTF_FILE "/sys/kernel/btf/vmlinux")
-option(USE_BUILTIN_VMLINUX "If true, use the builtin vmlinux.h for building BPF probes instead of generating one from system BTF" True)
+option(USE_BUILTIN_VMLINUX "If true, use the builtin vmlinux.h for building eBPF probes instead of generating one from system BTF" True)
 
 # Standard includes
 execute_process(COMMAND ${CLANG} -print-file-name=include

--- a/cmake/modules/arch.cmake
+++ b/cmake/modules/arch.cmake
@@ -5,8 +5,13 @@
 # you may not use this file except in compliance with the Elastic License 2.0.
 
 if (NOT ARCH)
-    set(ARCH "${CMAKE_HOST_SYSTEM_PROCESSOR}")
+    log(FATAL_ERROR "An architecture must be specified, either \"aarch64\" or \"x86_64\" via -DARCH=<arch>")
 endif()
-if (NOT ARCH_TRUNC)
-    string(REPLACE "x86_64" "x86" ARCH_TRUNC ${ARCH})
+
+if (ARCH STREQUAL "x86_64")
+    set(ARCH_TRUNC "x86")
+elseif(ARCH STREQUAL "aarch64")
+    set(ARCH_TRUNC "arm64")
+else()
+    log(FATAL_ERROR "Invalid architecture ${ARCH}")
 endif()

--- a/cmake/modules/libbpf.cmake
+++ b/cmake/modules/libbpf.cmake
@@ -8,20 +8,49 @@ set(LIBBPF_CONTRIB_DEFAULT "${PROJECT_SOURCE_DIR}/contrib/libbpf")
 set(LIBBPF_CONTRIB "${LIBBPF_CONTRIB_DEFAULT}" CACHE STRING "Custom libbpf source directory")
 
 set(LIBBPF_SRC "${LIBBPF_CONTRIB}/src")
-set(LIBBPF_BUILD_DIR "${PROJECT_BINARY_DIR}/libbpf-prefix/src/libbpf-build")
-set(LIBBPF_TARGET_INCLUDE_DIR "${PROJECT_BINARY_DIR}/libbpf-prefix/src/libbpf-target")
-set(LIBBPF_INCLUDE_DIR "${LIBBPF_CONTRIB}/include")
-set(LIBBPF_UAPI_INCLUDE_DIR "${LIBBPF_INCLUDE_DIR}/uapi")
+set(LIBBPF_BUILD_DIR "${PROJECT_BINARY_DIR}/libbpf-external-prefix/src/libbpf-external-build")
+set(LIBBPF_TARGET_INCLUDE_DIR "${PROJECT_BINARY_DIR}/libbpf-external-prefix/src/libbpf-external-target")
 set(LIBBPF_LIB "${LIBBPF_BUILD_DIR}/libbpf.a")
 
-message(STATUS "[contrib] libbpf in '${LIBBPF_CONTRIB}'")
+# This is somewhat ugly and makes me sad but is unfortunately necessary.
+#
+# This repository needs to be buildable as a part of projects where the kernel
+# headers aren't available or (ahem... looking at you endpoint) too old to be
+# useable (e.g. linux/bpf.h is absent).
+#
+# Libbpf ships with a _subset_ of the newer kernel headers that are new enough
+# to build this repository. We define a cache variable here pointing to that
+# directory and do target_include_directories(... PRIVATE ${LIBBPF_UAPI_INCLUDE_DIR})
+# on all targets that need Linux headers.
+#
+# We need to ensure that we make these headers a PRIVATE include. If we make it
+# PUBLIC, it'll propagate to other targets that link against the libraries in
+# this repository, and, if those targets also include older linux headers from
+# their toolchains, we'll be including two different sets of Linux headers
+# corresponding to different kernel versions. This can lead to build failures
+# as the headers were never meant to be used like this.
+set(LIBBPF_UAPI_INCLUDE_DIR "${LIBBPF_CONTRIB}/include/uapi"
+    CACHE INTERNAL "Path to subset of UAPI headers that ship with libbpf")
 
 ExternalProject_Add(
-    libbpf
+    libbpf-external
     DOWNLOAD_COMMAND ""
     CONFIGURE_COMMAND ""
     BUILD_COMMAND CC=${CMAKE_C_COMPILER} ${EBPF_EXTERNAL_ENV_FLAGS} make -C ${LIBBPF_SRC} BUILD_STATIC_ONLY=1 NO_PKG_CONFIG=1 OBJDIR=${LIBBPF_BUILD_DIR} INCLUDEDIR= LIBDIR= UAPIDIR= CFLAGS=${CMAKE_C_FLAGS} DESTDIR=${LIBBPF_TARGET_INCLUDE_DIR} install
     BUILD_IN_SOURCE 0
     INSTALL_COMMAND ""
-    BUILD_BYPRODUCTS ${LIBBPF_LIB}
+    BUILD_BYPRODUCTS ${LIBBPF_LIB} ${LIBBPF_TARGET_INCLUDE_DIR}
 )
+
+# https://gitlab.kitware.com/cmake/cmake/-/issues/15052
+#
+# INTERFACE_INCLUDE_DIRECTORIES cannot include a nonexistent directory but
+# ${LIBBPF_TARGET_INCLUDE_DIR} is created at build time. Create it here as a
+# workaround
+file(MAKE_DIRECTORY "${LIBBPF_TARGET_INCLUDE_DIR}")
+
+add_library(libbpf STATIC IMPORTED GLOBAL)
+set_property(TARGET libbpf PROPERTY IMPORTED_LOCATION "${LIBBPF_LIB}")
+set_property(TARGET libbpf PROPERTY INTERFACE_INCLUDE_DIRECTORIES "${LIBBPF_TARGET_INCLUDE_DIR}")
+set_property(TARGET libbpf PROPERTY INTERFACE_LINK_LIBRARIES "libelf;-lz")
+add_dependencies(libbpf libbpf-external)

--- a/cmake/modules/libelf.cmake
+++ b/cmake/modules/libelf.cmake
@@ -4,14 +4,12 @@
 # or more contributor license agreements. Licensed under the Elastic License 2.0;
 # you may not use this file except in compliance with the Elastic License 2.0.
 
-
 set(LIBELF_SRC "${PROJECT_SOURCE_DIR}/contrib/elftoolchain")
-set(LIBELF_BUILD_DIR "${PROJECT_BINARY_DIR}/libelf-prefix/src/libelf-build")
+set(LIBELF_BUILD_DIR "${PROJECT_BINARY_DIR}/libelf-external-prefix/src/libelf-external-build")
 set(LIBELF_LIB "${LIBELF_BUILD_DIR}/libelf.a")
-message(STATUS "[contrib] libelf (elftoolchain) in '${LIBELF_SRC}'")
 
 ExternalProject_Add(
-    libelf
+    libelf-external
     DOWNLOAD_COMMAND ""
     CONFIGURE_COMMAND ""
     BUILD_COMMAND CC=${CMAKE_C_COMPILER} ${EBPF_EXTERNAL_ENV_FLAGS} MFLAGS= MAKEFLAGS= WITH_TESTS=no WITH_BUILD_TOOLS=no WITH_ADDITIONAL_DOCUMENTATION=no WITH_PE=no WITH_ISA=no MAKEOBJDIR=${LIBELF_BUILD_DIR} bmake -C ${LIBELF_SRC} -e
@@ -19,3 +17,7 @@ ExternalProject_Add(
     INSTALL_COMMAND ""
     BUILD_BYPRODUCTS ${LIBELF_LIB}
 )
+
+add_library(libelf STATIC IMPORTED GLOBAL)
+set_property(TARGET libelf PROPERTY IMPORTED_LOCATION "${LIBELF_LIB}")
+add_dependencies(libelf libelf-external)

--- a/non-GPL/Events/EventsTrace/CMakeLists.txt
+++ b/non-GPL/Events/EventsTrace/CMakeLists.txt
@@ -6,18 +6,12 @@
 
 add_executable(EventsTrace EventsTrace.c)
 add_dependencies(EventsTrace EbpfEvents EventProbe_skeleton libbpf libelf)
-target_link_libraries(EventsTrace EbpfEvents ${LIBBPF_LIB} ${LIBELF_LIB} -lz)
+target_link_libraries(EventsTrace EbpfEvents)
 
 if (BUILD_STATIC_EVENTSTRACE)
     target_link_libraries(EventsTrace -static)
 endif()
 
 target_include_directories(EventsTrace PRIVATE
-    "${LIBBPF_TARGET_INCLUDE_DIR}"
-    "${LIBBPF_UAPI_INCLUDE_DIR}"
-    "${LIBBPF_INCLUDE_DIR}"
     "${CMAKE_SOURCE_DIR}/GPL/Events"
-    "${TARGET_INCLUDE_DIR}"
-    "${LIBBPF_TARGET_INCLUDE_DIR}"
-    "${LIBBPF_UAPI_INCLUDE_DIR}"
 )

--- a/non-GPL/Events/Lib/CMakeLists.txt
+++ b/non-GPL/Events/Lib/CMakeLists.txt
@@ -4,11 +4,14 @@
 # or more contributor license agreements. Licensed under the Elastic License 2.0;
 # you may not use this file except in compliance with the Elastic License 2.0.
 
-add_library(EbpfEvents EbpfEvents.c)
+add_library(EbpfEvents STATIC EbpfEvents.c)
 add_dependencies(EbpfEvents EventProbe_skeleton libbpf BPFEventProbe)
-target_include_directories(EbpfEvents PRIVATE
-    "${TARGET_INCLUDE_DIR}"
-    "${LIBBPF_TARGET_INCLUDE_DIR}"
-    "${LIBBPF_UAPI_INCLUDE_DIR}")
+target_link_libraries(EbpfEvents libbpf)
 
-configure_file(EbpfEvents.h ${TARGET_INCLUDE_DIR} COPYONLY)
+target_include_directories(EbpfEvents
+    PRIVATE
+    "${LIBBPF_UAPI_INCLUDE_DIR}"
+    PUBLIC
+    "${CMAKE_CURRENT_SOURCE_DIR}"
+    "${PROJECT_BINARY_DIR}/GPL/Events"  # For the skeleton header
+    "${PROJECT_SOURCE_DIR}/GPL/Events") # For EbpfEventProto.h

--- a/non-GPL/HostIsolation/Demos/CMakeLists.txt
+++ b/non-GPL/HostIsolation/Demos/CMakeLists.txt
@@ -5,12 +5,11 @@
 # you may not use this file except in compliance with the Elastic License 2.0.
 function(add_demo name)
     add_executable("${name}" "${name}.c")
-    target_include_directories(${name} PRIVATE
-        "${LIBBPF_TARGET_INCLUDE_DIR}"
+    target_include_directories(${name}
+        PRIVATE
         "${LIBBPF_UAPI_INCLUDE_DIR}"
-        "${LIBBPF_INCLUDE_DIR}"
         "${PROJECT_SOURCE_DIR}/non-GPL/HostIsolation/Lib")
-    target_link_libraries("${name}" PRIVATE HostIsolation)
+    target_link_libraries("${name}" PRIVATE EbpfHostIsolation)
 endfunction()
 
 add_demo(TcLoaderDemo)

--- a/non-GPL/HostIsolation/Lib/CMakeLists.txt
+++ b/non-GPL/HostIsolation/Lib/CMakeLists.txt
@@ -4,24 +4,16 @@
 # or more contributor license agreements. Licensed under the Elastic License 2.0;
 # you may not use this file except in compliance with the Elastic License 2.0.
 
-add_library(HostIsolation STATIC
+add_library(EbpfHostIsolation STATIC
     TcLoader.c
     KprobeLoader.c
     UpdateMaps.c
     Common.c)
 
-target_include_directories(HostIsolation PRIVATE
-    "${CMAKE_CURRENT_SOURCE_DIR}"
-    "${LIBBPF_TARGET_INCLUDE_DIR}"
+target_include_directories(EbpfHostIsolation
+    PRIVATE
     "${LIBBPF_UAPI_INCLUDE_DIR}"
-    "${LIBBPF_INCLUDE_DIR}")
+    PUBLIC
+    "${CMAKE_CURRENT_SOURCE_DIR}")
 
-add_dependencies(HostIsolation libbpf libelf)
-target_link_libraries(
-    HostIsolation ${LIBBPF_LIB} ${LIBELF_LIB} -lz)
-add_dependencies(HostIsolation libbpf libelf)
-
-configure_file(TcLoader.h ${TARGET_INCLUDE_DIR} COPYONLY)
-configure_file(KprobeLoader.h ${TARGET_INCLUDE_DIR} COPYONLY)
-configure_file(UpdateMaps.h ${TARGET_INCLUDE_DIR} COPYONLY)
-configure_file(Common.h ${TARGET_INCLUDE_DIR} COPYONLY)
+target_link_libraries(EbpfHostIsolation libbpf)


### PR DESCRIPTION
This commit cleans up the cmake in this repository, removing a lot of
vestigial stuff from when this repo was just host isolation and putting
it in a state where it can be more cleanly built with endpoint.

Changes:

- Remove all the TARGET_* variables in the top level CMakelists.txt,
  push all that logic down to lower subdirectories
- Create a "libbpf" and "libelf" library target, instead of linking
  against `${LIBBPF_LIB}` and `${LIBELF_LIB}` and then manually including
  the required includes. This puts logic pertaining to where to find
  libbpf includes in cmake/libbpf.cmake instead of GPL/non-GPL, which
  means that we don't have to manually add the libbpf include
  directories and link libraries to every target that links against it.
- Remove a bunch of unneeded comments, message(...) invocations etc.
- Clean up the variables in cmake/libbpf.cmake and document why we need
  the one (LIBBPF_UAPI_INCLUDE_DIR) that remains
- Set ARCH_TRUNC based on ARCH, don't require a higher level project to
  manually specify it

Note that to get this PR building with endpoint, one LLVM intrinsic has been commented out as the endpoint toolchain
is currently using LLVM 11, which doesn't support `bpf_core_enum_value_exists` (see comment). This has been done to get reviews in early and will be removed when the toolchain is updated to LLVM 14. _This PR should *not* be merged until the toolchain is updated and the commented-out code has been removed_.