### PR TITLE
Fix endpoint build issues

### DIFF
--- a/GPL/Events/Process/Probe.bpf.c
+++ b/GPL/Events/Process/Probe.bpf.c
@@ -16,7 +16,6 @@
 #include "Helpers.h"
 #include "PathResolver.h"
 
-
 // TODO: Re-enable tty_write probe when BTF issues are fixed
 #if 0
 /* tty_write */

--- a/GPL/Events/Process/Probe.bpf.c
+++ b/GPL/Events/Process/Probe.bpf.c
@@ -16,11 +16,15 @@
 #include "Helpers.h"
 #include "PathResolver.h"
 
+
+// TODO: Re-enable tty_write probe when BTF issues are fixed
+#if 0
 /* tty_write */
 DECL_FUNC_ARG(tty_write, from);
 DECL_FUNC_ARG(tty_write, buf);
 DECL_FUNC_ARG(tty_write, count);
 DECL_FUNC_ARG_EXISTS(tty_write, from);
+#endif
 
 SEC("tp_btf/sched_process_fork")
 int BPF_PROG(sched_process_fork, const struct task_struct *parent, const struct task_struct *child)
@@ -241,6 +245,8 @@ int BPF_KPROBE(kprobe__commit_creds, struct cred *new)
     return commit_creds__enter(new);
 }
 
+// TODO: Re-enable tty_write probe when BTF issues are fixed
+#if 0
 static int tty_write__enter(const char *buf, ssize_t count)
 {
     if (is_consumer())
@@ -322,3 +328,4 @@ int BPF_KPROBE(kprobe__tty_write)
 out:
     return 0;
 }
+#endif

--- a/GPL/HostIsolation/TcFilter/CMakeLists.txt
+++ b/GPL/HostIsolation/TcFilter/CMakeLists.txt
@@ -39,6 +39,7 @@ target_include_directories(BPFTcFilterTests
 
 add_dependencies(BPFTcFilterTests BPFTcFilter)
 
-target_link_libraries(BPFTcFilterTests libbpf ${GTEST_LIB} -pthread)
+# TODO: Remove "-lz" once we've vendored in libz
+target_link_libraries(BPFTcFilterTests libbpf ${GTEST_LIB} -pthread -lz)
 add_dependencies(BPFTcFilterTests libbpf libelf gtest)
 

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 ARCH ?= $(shell arch)
 
 DOCKER_IMAGE = us-docker.pkg.dev/elastic-security-dev/ebpf-public/builder
-DOCKER_PULL_TAG = 20220711-1742
+DOCKER_PULL_TAG = 20220803-1801
 DOCKER_LOCAL_TAG = ${USER}-latest
 CURRENT_DATE_TAG = $(shell date +%Y%m%d-%H%M)
 
@@ -58,10 +58,10 @@ _internal-build:
 	make VERBOSE=1 -C${BUILD_DIR} -j$(shell nproc)
 
 container:
-	docker build -t ${DOCKER_LOCAL_TAG} -f docker/Dockerfile.builder .
+	docker build -t ${DOCKER_IMAGE}:${DOCKER_LOCAL_TAG} -f docker/Dockerfile.builder .
 
 tag-container:
-	docker tag ${DOCKER_IMAGE}:${DOCKER_LOCAL_TAG} ${DOCKER_IMAGE}:$CURRENT_DATE_TAG
+	docker tag ${DOCKER_IMAGE}:${DOCKER_LOCAL_TAG} ${DOCKER_IMAGE}:${CURRENT_DATE_TAG}
 	@echo "\n++ Tagged image as ${DOCKER_IMAGE}:${CURRENT_DATE_TAG} ++\n"
 
 # We dockerize code formatting because differences in clang-format versions can

--- a/cmake/modules/libbpf.cmake
+++ b/cmake/modules/libbpf.cmake
@@ -52,5 +52,11 @@ file(MAKE_DIRECTORY "${LIBBPF_TARGET_INCLUDE_DIR}")
 add_library(libbpf STATIC IMPORTED GLOBAL)
 set_property(TARGET libbpf PROPERTY IMPORTED_LOCATION "${LIBBPF_LIB}")
 set_property(TARGET libbpf PROPERTY INTERFACE_INCLUDE_DIRECTORIES "${LIBBPF_TARGET_INCLUDE_DIR}")
-set_property(TARGET libbpf PROPERTY INTERFACE_LINK_LIBRARIES "libelf;-lz")
+
+# TODO: Update this to be libelf;libz when we've vendored-in libz, and remove
+# -lz from all targets that link to it. If we do -lz here, targets linking to
+# libEbpfEvents will dynamically link to libz, which is not desirable in
+# endpoint
+set_property(TARGET libbpf PROPERTY INTERFACE_LINK_LIBRARIES "libelf")
+
 add_dependencies(libbpf libbpf-external)

--- a/non-GPL/Events/EventsTrace/CMakeLists.txt
+++ b/non-GPL/Events/EventsTrace/CMakeLists.txt
@@ -6,7 +6,9 @@
 
 add_executable(EventsTrace EventsTrace.c)
 add_dependencies(EventsTrace EbpfEvents EventProbe_skeleton libbpf libelf)
-target_link_libraries(EventsTrace EbpfEvents)
+
+# TODO: Remove "libbpf -lz" once we've vendored in libz
+target_link_libraries(EventsTrace EbpfEvents libbpf -lz)
 
 if (BUILD_STATIC_EVENTSTRACE)
     target_link_libraries(EventsTrace -static)

--- a/non-GPL/Events/Lib/EbpfEvents.c
+++ b/non-GPL/Events/Lib/EbpfEvents.c
@@ -190,12 +190,15 @@ static int probe_fill_relos(struct btf *btf, struct EventProbe_bpf *obj)
     }
     err = err ?: FILL_FUNC_RET_IDX(obj, btf, vfs_rename);
 
+    // TODO: Re-enable tty_write probe when BTF issues are fixed
+#if 0
     if (FILL_FUNC_ARG_EXISTS(obj, btf, tty_write, from)) {
         err = err ?: FILL_FUNC_ARG_IDX(obj, btf, tty_write, buf);
         err = err ?: FILL_FUNC_ARG_IDX(obj, btf, tty_write, count);
     } else {
         err = err ?: FILL_FUNC_ARG_IDX(obj, btf, tty_write, from);
     }
+#endif
 
     return err;
 }
@@ -243,7 +246,10 @@ static inline int probe_set_autoload(struct btf *btf, struct EventProbe_bpf *obj
         err = err ?: bpf_program__set_autoload(obj->progs.kprobe__tcp_v4_connect, false);
         err = err ?: bpf_program__set_autoload(obj->progs.kretprobe__tcp_v4_connect, false);
         err = err ?: bpf_program__set_autoload(obj->progs.kprobe__tcp_close, false);
+        // TODO: Re-enable tty_write probe when BTF issues are fixed
+#if 0
         err = err ?: bpf_program__set_autoload(obj->progs.kprobe__tty_write, false);
+#endif
     } else {
         err = err ?: bpf_program__set_autoload(obj->progs.fentry__do_unlinkat, false);
         err = err ?: bpf_program__set_autoload(obj->progs.fentry__mnt_want_write, false);
@@ -257,7 +263,10 @@ static inline int probe_set_autoload(struct btf *btf, struct EventProbe_bpf *obj
         err = err ?: bpf_program__set_autoload(obj->progs.fexit__inet_csk_accept, false);
         err = err ?: bpf_program__set_autoload(obj->progs.fexit__tcp_v4_connect, false);
         err = err ?: bpf_program__set_autoload(obj->progs.fentry__tcp_close, false);
+        // TODO: Re-enable tty_write probe when BTF issues are fixed
+#if 0
         err = err ?: bpf_program__set_autoload(obj->progs.fentry__tty_write, false);
+#endif
     }
 
     return err;

--- a/non-GPL/HostIsolation/Demos/CMakeLists.txt
+++ b/non-GPL/HostIsolation/Demos/CMakeLists.txt
@@ -9,7 +9,9 @@ function(add_demo name)
         PRIVATE
         "${LIBBPF_UAPI_INCLUDE_DIR}"
         "${PROJECT_SOURCE_DIR}/non-GPL/HostIsolation/Lib")
-    target_link_libraries("${name}" PRIVATE EbpfHostIsolation)
+
+    # TODO: Remove -lz once we've vendored in libz
+    target_link_libraries("${name}" PRIVATE EbpfHostIsolation libbpf -lz)
 endfunction()
 
 add_demo(TcLoaderDemo)

--- a/testing/testrunner/main.go
+++ b/testing/testrunner/main.go
@@ -22,7 +22,9 @@ func main() {
 	RunTest(TestFileCreate, "--file-create")
 	RunTest(TestFileDelete, "--file-delete")
 	RunTest(TestFileRename, "--file-rename")
-	RunTest(TestTtyWrite, "--process-tty-write")
+
+	// TODO: Re-enable tty_write probe when BTF issues are fixed
+	// RunTest(TestTtyWrite, "--process-tty-write")
 
 	// These tests rely on overlayfs support. Distro kernels commonly compile
 	// overlayfs as a module, thus it's not available to us in our


### PR DESCRIPTION
This PR fixes two endpoint build issues.

- `libbpf` did `target_link_libraries(libbpf ... -lz)`, which resulted in the library _dynamically_ linking to libz, which we can't have with endpoint. Remove the `-lz` target link library from libbpf and just manually add it in all test/utility executables that need it. We'll statically link it in the endpoint build. It should be replaced with the vendored libz when that's added
- The `tty_write` probe is broken on kernels that have been built with pahole < 1.22. The reason for this is involved, see spoiler below if you're interested. For the time being, ifdef it out to get the endpoint build working (we don't need tty_write data right now). Once we have a working endpoint build, I'll get to fixing it.

<details>
<summary>tty_write problem details</summary>

[pahole](https://github.com/acmel/dwarves) is the tool run during the kernel build process to generate BTF information. Pre Pahole 1.22 however, it would not generate BTF information for the signature of tty_write on ARM64 (x86 works fine).

[This change](https://github.com/acmel/dwarves/commit/58a98f76ac95b1bb11920ff2b58206b2364e6b3b) inadvertently fixed things in 1.22. Basically, they wanted to limit the amount of BTF generated to save space, so they only generated BTF for functions that matched certain criteria. One of those criteria was that a function had to be known to ftrace. This was a reasonable assumption as functions known to ftrace are the most likely to be traced, and thus the most likely to require BTF type information (so BTF probes can nicely parse their arguments). The change I cited removed this constraint, as it was decided that BTF information can be generated for everything and that the utility outweighs the extra space.

Now the list of functions known to ftrace is stored in a list in the kernel binary started by the symbol `__mcount_loc_start` and ended by the symbol `__mcount_loc_end`. If you just map the binary into memory using mmap and seek to that symbol, theoretically you'll have a list of addresses that correspond to functions known to ftrace, and indeed, on x86 this is the case.

For an ARM64 build however (with the default kernel config), that list is entirely nulls. The reason for this is that instead of just putting the addresses inline in the list, on an ARM64 build, the kernel build process leaves the list in the binary as nulls, and then generates a bunch of relocations such that the list is filled in by the kernel when it's patching up relocations at boot. Naturally then, that list will be populated when the kernel is booted, but if you just map the kernel binary into memory (as pahole does at build time) and try to read from the array to get the ftrace list, it'll just be nulls.

This difference in behaviour is due to the fact that the ARM64 build uses the [recordmcount](https://github.com/torvalds/linux/blob/master/scripts/recordmcount.c) script at build time to generate the array (which generates relocations for each item) while on x86, this is done in GCC via the -mrecord-mcount flag (which doesn't generate relocations, it just puts the data straight up in the list). These relocations can be inlined at build time by disabling `CONFIG_RELOCATABLE`, but seems almost no ARM64 kernels do this.

If you're interested in why ftrace needs that list see: https://www.brendangregg.com/blog/2019-10-15/kernelrecipes-kernel-ftrace-internals.html (excellent talk)
</details>