### PR TITLE
EventProbe: use redirected_tty_write BTF info instead of tty_write

### DIFF
--- a/GPL/Events/EbpfEventProto.h
+++ b/GPL/Events/EbpfEventProto.h
@@ -142,7 +142,7 @@ struct ebpf_process_tty_write_event {
     struct ebpf_pid_info pids;
     char tty_out[TTY_OUT_MAX];
     uint64_t tty_out_len;
-    uint8_t tty_out_truncated;
+    uint64_t tty_out_truncated;
 } __attribute__((packed));
 
 struct ebpf_process_setgid_event {

--- a/GPL/Events/Process/Probe.bpf.c
+++ b/GPL/Events/Process/Probe.bpf.c
@@ -16,14 +16,11 @@
 #include "Helpers.h"
 #include "PathResolver.h"
 
-// TODO: Re-enable tty_write probe when BTF issues are fixed
-#if 0
 /* tty_write */
-DECL_FUNC_ARG(tty_write, from);
-DECL_FUNC_ARG(tty_write, buf);
-DECL_FUNC_ARG(tty_write, count);
-DECL_FUNC_ARG_EXISTS(tty_write, from);
-#endif
+DECL_FUNC_ARG(redirected_tty_write, iter);
+DECL_FUNC_ARG(redirected_tty_write, buf);
+DECL_FUNC_ARG(redirected_tty_write, count);
+DECL_FUNC_ARG_EXISTS(redirected_tty_write, iter);
 
 SEC("tp_btf/sched_process_fork")
 int BPF_PROG(sched_process_fork, const struct task_struct *parent, const struct task_struct *child)
@@ -244,8 +241,6 @@ int BPF_KPROBE(kprobe__commit_creds, struct cred *new)
     return commit_creds__enter(new);
 }
 
-// TODO: Re-enable tty_write probe when BTF issues are fixed
-#if 0
 static int tty_write__enter(const char *buf, ssize_t count)
 {
     if (is_consumer())
@@ -258,16 +253,17 @@ static int tty_write__enter(const char *buf, ssize_t count)
     if (!event)
         goto out;
 
-    event->hdr.type          = EBPF_EVENT_PROCESS_TTY_WRITE;
-    event->hdr.ts            = bpf_ktime_get_ns();
-    event->tty_out_len       = count;
-    event->tty_out_truncated = count > TTY_OUT_MAX ? 1 : 0;
+    event->hdr.type = EBPF_EVENT_PROCESS_TTY_WRITE;
+    event->hdr.ts   = bpf_ktime_get_ns();
+
+    u64 len                  = count > TTY_OUT_MAX ? TTY_OUT_MAX : count;
+    event->tty_out_len       = len;
+    event->tty_out_truncated = count > TTY_OUT_MAX ? count - TTY_OUT_MAX : 0;
 
     const struct task_struct *task = (struct task_struct *)bpf_get_current_task();
     ebpf_pid_info__fill(&event->pids, task);
 
-    if (bpf_probe_read_user(event->tty_out, count > TTY_OUT_MAX ? TTY_OUT_MAX : count,
-                            (void *)buf)) {
+    if (bpf_probe_read_user(event->tty_out, len, (void *)buf)) {
         bpf_printk("tty_write__enter: error reading buf\n");
         bpf_ringbuf_discard(event, 0);
         goto out;
@@ -285,13 +281,13 @@ int BPF_PROG(fentry__tty_write)
     const char *buf;
     ssize_t count;
 
-    if (FUNC_ARG_EXISTS(tty_write, from)) {
-        struct iov_iter *ii = FUNC_ARG_READ(___type(ii), tty_write, from);
+    if (FUNC_ARG_EXISTS(redirected_tty_write, iter)) {
+        struct iov_iter *ii = FUNC_ARG_READ(___type(ii), redirected_tty_write, iter);
         buf                 = BPF_CORE_READ(ii, iov, iov_base);
         count               = BPF_CORE_READ(ii, iov, iov_len);
     } else {
-        buf   = FUNC_ARG_READ(___type(buf), tty_write, buf);
-        count = FUNC_ARG_READ(___type(count), tty_write, count);
+        buf   = FUNC_ARG_READ(___type(buf), redirected_tty_write, buf);
+        count = FUNC_ARG_READ(___type(count), redirected_tty_write, count);
     }
 
     return tty_write__enter(buf, count);
@@ -303,20 +299,20 @@ int BPF_KPROBE(kprobe__tty_write)
     const char *buf;
     ssize_t count;
 
-    if (FUNC_ARG_EXISTS(tty_write, from)) {
+    if (FUNC_ARG_EXISTS(redirected_tty_write, iter)) {
         struct iov_iter ii;
-        if (FUNC_ARG_READ_PTREGS(ii, tty_write, from)) {
+        if (FUNC_ARG_READ_PTREGS(ii, redirected_tty_write, iter)) {
             bpf_printk("kprobe__tty_write: error reading iov_iter\n");
             goto out;
         }
         buf   = BPF_CORE_READ(ii.iov, iov_base);
         count = BPF_CORE_READ(ii.iov, iov_len);
     } else {
-        if (FUNC_ARG_READ_PTREGS(buf, tty_write, buf)) {
+        if (FUNC_ARG_READ_PTREGS(buf, redirected_tty_write, buf)) {
             bpf_printk("kprobe__tty_write: error reading buf\n");
             goto out;
         }
-        if (FUNC_ARG_READ_PTREGS(count, tty_write, count)) {
+        if (FUNC_ARG_READ_PTREGS(count, redirected_tty_write, count)) {
             bpf_printk("kprobe__tty_write: error reading count\n");
             goto out;
         }
@@ -327,4 +323,3 @@ int BPF_KPROBE(kprobe__tty_write)
 out:
     return 0;
 }
-#endif

--- a/non-GPL/Events/EventsTrace/EventsTrace.c
+++ b/non-GPL/Events/EventsTrace/EventsTrace.c
@@ -444,9 +444,9 @@ static void out_process_tty_write(struct ebpf_process_tty_write_event *evt)
 
     out_pid_info("pids", &evt->pids);
     out_comma();
-    out_int("tty_out_len", evt->tty_out_len);
+    out_uint("tty_out_len", evt->tty_out_len);
     out_comma();
-    out_int("tty_out_truncated", evt->tty_out_truncated);
+    out_uint("tty_out_truncated", evt->tty_out_truncated);
     out_comma();
     out_string("tty_out", evt->tty_out);
 

--- a/non-GPL/Events/Lib/EbpfEvents.c
+++ b/non-GPL/Events/Lib/EbpfEvents.c
@@ -239,6 +239,13 @@ static inline int probe_set_autoload(struct btf *btf, struct EventProbe_bpf *obj
         err = err ?: bpf_program__set_autoload(obj->progs.fexit__tcp_v6_connect, false);
     }
 
+    // tty_write is not present in all supported kernels' BTF info (eg. amazonlinux2 x86_64)
+    if (has_bpf_tramp && BTF_FUNC_EXISTS(btf, tty_write)) {
+        err = err ?: bpf_program__set_autoload(obj->progs.kprobe__tty_write, false);
+    } else {
+        err = err ?: bpf_program__set_autoload(obj->progs.fentry__tty_write, false);
+    }
+
     // bpf trampolines are only implemented for x86. disable auto-loading of all
     // fentry/fexit progs if EBPF_FEATURE_BPF_TRAMP is not in `features` and
     // enable the k[ret]probe counterpart.
@@ -256,7 +263,6 @@ static inline int probe_set_autoload(struct btf *btf, struct EventProbe_bpf *obj
         err = err ?: bpf_program__set_autoload(obj->progs.kprobe__tcp_v4_connect, false);
         err = err ?: bpf_program__set_autoload(obj->progs.kretprobe__tcp_v4_connect, false);
         err = err ?: bpf_program__set_autoload(obj->progs.kprobe__tcp_close, false);
-        err = err ?: bpf_program__set_autoload(obj->progs.kprobe__tty_write, false);
     } else {
         err = err ?: bpf_program__set_autoload(obj->progs.fentry__do_unlinkat, false);
         err = err ?: bpf_program__set_autoload(obj->progs.fentry__mnt_want_write, false);
@@ -270,7 +276,6 @@ static inline int probe_set_autoload(struct btf *btf, struct EventProbe_bpf *obj
         err = err ?: bpf_program__set_autoload(obj->progs.fexit__inet_csk_accept, false);
         err = err ?: bpf_program__set_autoload(obj->progs.fexit__tcp_v4_connect, false);
         err = err ?: bpf_program__set_autoload(obj->progs.fentry__tcp_close, false);
-        err = err ?: bpf_program__set_autoload(obj->progs.fentry__tty_write, false);
     }
 
     return err;

--- a/testing/run_tests.sh
+++ b/testing/run_tests.sh
@@ -5,7 +5,6 @@
 # one or more contributor license agreements. Licensed under the Elastic
 # License 2.0; you may not use this file except in compliance with the Elastic
 # License 2.0.
-set -x
 readonly PROGNAME=$(basename $0)
 readonly ARGS="$@"
 
@@ -42,9 +41,13 @@ run_tests() {
     echo "BPF-check run for $# $arch kernel(s) at $(date)" > $SUMMARY_FILE
     for f in $RESULTS_DIR/*; do
         local kern=$(basename $f .txt)
-        grep "$SUCCESS_STRING" $f \
-            && echo "PASS: $kern" >> $SUMMARY_FILE \
-            || echo "FAIL: $kern" >> $SUMMARY_FILE
+        if grep -q "$SUCCESS_STRING" $f; then
+            echo "PASS: $kern" >> $SUMMARY_FILE
+        else
+            echo "FAIL: $kern" >> $SUMMARY_FILE
+            echo "TEST OUTPUT"
+            cat $f
+        fi
     done
 }
 

--- a/testing/scripts/build_mainline_kernels.sh
+++ b/testing/scripts/build_mainline_kernels.sh
@@ -15,7 +15,6 @@
 
 readonly PROGNAME=$(basename $0)
 readonly ARGS="$@"
-set -x
 
 output_kernel_builder() {
     cat <<"EOF" >$1

--- a/testing/testrunner/main.go
+++ b/testing/testrunner/main.go
@@ -22,9 +22,7 @@ func main() {
 	RunTest(TestFileCreate, "--file-create")
 	RunTest(TestFileDelete, "--file-delete")
 	RunTest(TestFileRename, "--file-rename")
-
-	// TODO: Re-enable tty_write probe when BTF issues are fixed
-	// RunTest(TestTtyWrite, "--process-tty-write")
+	RunTest(TestTtyWrite, "--process-tty-write")
 
 	// These tests rely on overlayfs support. Distro kernels commonly compile
 	// overlayfs as a module, thus it's not available to us in our


### PR DESCRIPTION
Use a different function to obtain signature indexes as `tty_write` BTF info are missing on ARM systems. Read more: https://github.com/elastic/ebpf/pull/116#issue-1327583872

Co-Authored-By: Rhys Rustad-Elliott <rhys.rustad-elliott@elastic.co>
