### PR TITLE
Fix probes not loading on kernels with the PREEMPT_RT patch

### DIFF
--- a/GPL/Events/Process/Probe.bpf.c
+++ b/GPL/Events/Process/Probe.bpf.c
@@ -154,7 +154,7 @@ int tracepoint_syscalls_sys_exit_setsid(struct trace_event_raw_sys_exit *args)
     if (is_kernel_thread(task))
         goto out;
 
-    if (args->ret < 0)
+    if (BPF_CORE_READ(args, ret) < 0)
         goto out;
 
     struct ebpf_process_setsid_event *event = bpf_ringbuf_reserve(&ringbuf, sizeof(*event), 0);

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ EVENTSTRACE_PATH ?= ${PWD}/artifacts-${ARCH}/package/bin/EventsTrace
 
 # Debug settings
 ifdef DEBUG
-	CMAKE_FLAGS = ${CMAKE_FLAGS} -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_FLAGS="-g -O0"
+	CMAKE_FLAGS += -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_FLAGS="-g -O0"
 endif
 
 # Directories to search recursively for c/cpp source files to clang-format


### PR DESCRIPTION
On kernels with the PREEMPT_RT patch, the trace_entry struct, which
is the first member of trace_event_raw_sys_exit struct (the ctx for the
setsid exit probe) has two extra members.

We access the ret field of ctx via ctx->ret, which compiles to a
hardcoded offset. We should be using BPF_CORE_READ such that a
relocation is emitted so the correct offset is accessed on rt kernels.