### PR TITLE
Skeleton headers for host isolation

### DIFF
--- a/non-GPL/Events/EventsTrace/EventsTrace.c
+++ b/non-GPL/Events/EventsTrace/EventsTrace.c
@@ -666,7 +666,7 @@ int main(int argc, char **argv)
     if (g_features_autodetect)
         ebpf_detect_system_features(&opts.features);
 
-    err = ebpf_event_ctx__new(&ctx, event_ctx_callback, opts, 0);
+    err = ebpf_event_ctx__new(&ctx, event_ctx_callback, opts, /* dry_run= */ false);
 
     if (err < 0) {
         fprintf(stderr, "Could not create event context: %d %s\n", err, strerror(-err));

--- a/non-GPL/Events/EventsTrace/EventsTrace.c
+++ b/non-GPL/Events/EventsTrace/EventsTrace.c
@@ -666,7 +666,7 @@ int main(int argc, char **argv)
     if (g_features_autodetect)
         ebpf_detect_system_features(&opts.features);
 
-    err = ebpf_event_ctx__new(&ctx, event_ctx_callback, opts);
+    err = ebpf_event_ctx__new(&ctx, event_ctx_callback, opts, 0);
 
     if (err < 0) {
         fprintf(stderr, "Could not create event context: %d %s\n", err, strerror(-err));

--- a/non-GPL/Events/Lib/EbpfEvents.c
+++ b/non-GPL/Events/Lib/EbpfEvents.c
@@ -405,7 +405,8 @@ int ebpf_set_verbose_logging()
 
 int ebpf_event_ctx__new(struct ebpf_event_ctx **ctx,
                         ebpf_event_handler_fn cb,
-                        struct ebpf_event_ctx_opts opts)
+                        struct ebpf_event_ctx_opts opts,
+                        bool dry_run)
 {
     struct EventProbe_bpf *probe = NULL;
     struct btf *btf              = NULL;
@@ -469,8 +470,15 @@ int ebpf_event_ctx__new(struct ebpf_event_ctx **ctx,
     if (err != 0)
         goto out_destroy_probe;
 
-    if (!ctx)
+    if (dry_run) {
+        err = 0;
         goto out_destroy_probe;
+    }
+
+    if (!ctx) {
+        err = -ENOENT;
+        goto out_destroy_probe;
+    }
 
     *ctx = calloc(1, sizeof(struct ebpf_event_ctx));
     if (*ctx == NULL) {

--- a/non-GPL/Events/Lib/EbpfEvents.h
+++ b/non-GPL/Events/Lib/EbpfEvents.h
@@ -36,16 +36,17 @@ int ebpf_detect_system_features(uint64_t *features);
 
 /* Allocates a new context based on requested events and capabilities.
  *
- * If ctx is NULL, the function returns right after loading and attaching the
- * libbpf skeleton.
+ * If dry_run is true, the function only tests load and attach to
+ * verify host compatibility.
  *
  * Returns a positive int that represents an fd, which can be used with epoll
- * on success. Returns an error on failure. If ctx is NULL,
+ * on success. Returns an error on failure. If dry_run is true,
  * returns 0 on success or less than 0 on failure.
  */
 int ebpf_event_ctx__new(struct ebpf_event_ctx **ctx,
                         ebpf_event_handler_fn cb,
-                        struct ebpf_event_ctx_opts opts);
+                        struct ebpf_event_ctx_opts opts,
+                        bool dry_run);
 
 /* Consumes as many events as possible from the event context and returns the
  * number consumed.

--- a/non-GPL/HostIsolation/Lib/TcLoader.h
+++ b/non-GPL/HostIsolation/Lib/TcLoader.h
@@ -77,7 +77,7 @@ int netlink_filter_add_begin(struct netlink_ctx *ctx, const char *ifname);
  * @param[in] fd eBPF program file descriptor
  * @param[in] ctx Context containing netlink state (from previous add_begin()
  * call) - passed by caller
- * @param[in] ebpf_obj_filename eBPF object filename
+ * @param[in] ebpf_obj_filename eBPF object filename (NULL if using skeleton header)
  * @return Error value (0 for success)
  */
 int netlink_filter_add_end(int fd, struct netlink_ctx *ctx, const char *ebpf_obj_filename);


### PR DESCRIPTION
Changes required to use skeleton headers for host isolation.
It is still possible to use `*bpf.o` files and the Host Isolation demos continue to use those.