### PR TITLE
Prefer add_custom_command to add_custom_target

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,5 @@ testing/test_bins/bin/*
 testing/init/bin/*
 testing/kernels
 testing/virtme
+
+*.swp

--- a/cmake/modules/BPF.cmake
+++ b/cmake/modules/BPF.cmake
@@ -78,12 +78,14 @@ function (ebpf_probe_target target)
 
     set(EBPF_PROBE_DEPFILE ${CMAKE_CURRENT_BINARY_DIR}/${target}.bpf.d)
 
-    add_custom_target(${target}_Probe
+    add_custom_command(
+        OUTPUT ${OUT_FILE} ${SKEL_FILE}
         COMMAND ${EBPF_EXTERNAL_ENV_FLAGS} ${BPF_COMPILER} ${BPF_COMPILER_FLAGS} -MD -MF ${EBPF_PROBE_DEPFILE} ${EBPF_PROBE_FLAGS} -c ${EBPF_PROBE_SOURCES} -o ${OUT_FILE}
         COMMAND ${STRIP_CMD}
         COMMAND ${SKELETON_CMD}
-        BYPRODUCTS ${OUT_FILE} ${SKEL_FILE}
     )
+
+    add_custom_target(${target}_Probe DEPENDS ${OUT_FILE} ${SKEL_FILE})
 
     add_dependencies(${target}_Probe ${EBPF_PROBE_DEPENDENCIES} libbpf vmlinux)
 


### PR DESCRIPTION
Not sure why but `add_custom_target` always rebuilds non-GPL/Events/Lib/CMakeFiles/EbpfEvents.dir/EbpfEvents.c.o

Using a combo of `add_custom_command` and `add_custom_target` prevents the object file from being rebuilt when not necessary.