### PR TITLE
Track the probe source files

### DIFF
--- a/GPL/Events/CMakeLists.txt
+++ b/GPL/Events/CMakeLists.txt
@@ -30,7 +30,7 @@ ebpf_probe_target(EventProbe
     DEPENDENCIES libbpf vmlinux
     FLAGS ${EVENTS_PROBE_CFLAGS}
     PUBLIC_HEADERS EbpfEventProto.h
-    FILES
+    DEPENDS
     ${CMAKE_CURRENT_SOURCE_DIR}/File/Probe.bpf.c
     ${CMAKE_CURRENT_SOURCE_DIR}/Network/Probe.bpf.c
     ${CMAKE_CURRENT_SOURCE_DIR}/Network/Network.h

--- a/GPL/Events/CMakeLists.txt
+++ b/GPL/Events/CMakeLists.txt
@@ -35,6 +35,11 @@ ebpf_probe_target(EventProbe
     ${CMAKE_CURRENT_SOURCE_DIR}/Network/Probe.bpf.c
     ${CMAKE_CURRENT_SOURCE_DIR}/Network/Network.h
     ${CMAKE_CURRENT_SOURCE_DIR}/Process/Probe.bpf.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/EbpfEventProto.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/EventProbe.bpf.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/Helpers.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/PathResolver.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/State.h
     GENSKELETON INSTALL
 
 )

--- a/GPL/Events/CMakeLists.txt
+++ b/GPL/Events/CMakeLists.txt
@@ -30,5 +30,11 @@ ebpf_probe_target(EventProbe
     DEPENDENCIES libbpf vmlinux
     FLAGS ${EVENTS_PROBE_CFLAGS}
     PUBLIC_HEADERS EbpfEventProto.h
+    FILES
+    ${CMAKE_CURRENT_SOURCE_DIR}/File/Probe.bpf.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/Network/Probe.bpf.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/Network/Network.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/Process/Probe.bpf.c
     GENSKELETON INSTALL
+
 )

--- a/GPL/Events/CMakeLists.txt
+++ b/GPL/Events/CMakeLists.txt
@@ -41,5 +41,4 @@ ebpf_probe_target(EventProbe
     ${CMAKE_CURRENT_SOURCE_DIR}/PathResolver.h
     ${CMAKE_CURRENT_SOURCE_DIR}/State.h
     GENSKELETON INSTALL
-
 )

--- a/GPL/HostIsolation/KprobeConnectHook/CMakeLists.txt
+++ b/GPL/HostIsolation/KprobeConnectHook/CMakeLists.txt
@@ -19,7 +19,7 @@ ebpf_probe_target(KprobeConnectHook
     SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/KprobeConnectHook.bpf.c
     DEPENDENCIES libbpf vmlinux
     FLAGS ${KPROBECONNECTHOOK_CFLAGS}
-    FILES
+    DEPENDS
     ${CMAKE_CURRENT_SOURCE_DIR}/KprobeConnectHook.bpf.c
     ${CMAKE_CURRENT_SOURCE_DIR}/Kerneldefs.h
     GENSKELETON INSTALL

--- a/GPL/HostIsolation/KprobeConnectHook/CMakeLists.txt
+++ b/GPL/HostIsolation/KprobeConnectHook/CMakeLists.txt
@@ -19,5 +19,8 @@ ebpf_probe_target(KprobeConnectHook
     SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/KprobeConnectHook.bpf.c
     DEPENDENCIES libbpf vmlinux
     FLAGS ${KPROBECONNECTHOOK_CFLAGS}
+    FILES
+    ${CMAKE_CURRENT_SOURCE_DIR}/KprobeConnectHook.bpf.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/Kerneldefs.h
     GENSKELETON INSTALL
 )

--- a/GPL/HostIsolation/TcFilter/CMakeLists.txt
+++ b/GPL/HostIsolation/TcFilter/CMakeLists.txt
@@ -29,7 +29,7 @@ ebpf_probe_target(TcFilter
     DEPENDENCIES libbpf vmlinux
     FLAGS ${TCFILTER_CFLAGS}
     PUBLIC_HEADERS TcFilterdefs.h
-    FILES
+    DEPENDS
     ${CMAKE_CURRENT_SOURCE_DIR}/TcFilter.bpf.c
     ${CMAKE_CURRENT_SOURCE_DIR}/TcFilterdefs.h
     ${CMAKE_CURRENT_SOURCE_DIR}/Kerneldefs.h

--- a/GPL/HostIsolation/TcFilter/CMakeLists.txt
+++ b/GPL/HostIsolation/TcFilter/CMakeLists.txt
@@ -29,6 +29,10 @@ ebpf_probe_target(TcFilter
     DEPENDENCIES libbpf vmlinux
     FLAGS ${TCFILTER_CFLAGS}
     PUBLIC_HEADERS TcFilterdefs.h
+    FILES
+    ${CMAKE_CURRENT_SOURCE_DIR}/TcFilter.bpf.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/TcFilterdefs.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/Kerneldefs.h
     GENSKELETON INSTALL
 )
 

--- a/cmake/modules/BPF.cmake
+++ b/cmake/modules/BPF.cmake
@@ -57,7 +57,7 @@ add_dependencies(vmlinux vmlinux-external)
 
 function (ebpf_probe_target target)
     set(options OPTIONAL GENSKELETON INSTALL)
-    set(multiValueArgs FLAGS SOURCES DEPENDENCIES PUBLIC_HEADERS)
+    set(multiValueArgs FLAGS SOURCES DEPENDENCIES PUBLIC_HEADERS FILES)
 
     cmake_parse_arguments(EBPF_PROBE "${options}" ""
         "${multiValueArgs}" ${ARGN})
@@ -85,6 +85,7 @@ function (ebpf_probe_target target)
         COMMAND ${EBPF_EXTERNAL_ENV_FLAGS} ${BPF_COMPILER_ENV} ${BPF_COMPILER} ${BPF_COMPILER_FLAGS} -MD -MF ${EBPF_PROBE_DEPFILE} ${EBPF_PROBE_FLAGS} -c ${EBPF_PROBE_SOURCES} -o ${OUT_FILE}
         COMMAND ${STRIP_CMD}
         COMMAND ${SKELETON_CMD}
+        DEPENDS ${EBPF_PROBE_FILES}
     )
 
     add_custom_target(${target}_Probe DEPENDS ${OUT_FILE} ${SKEL_FILE})

--- a/cmake/modules/BPF.cmake
+++ b/cmake/modules/BPF.cmake
@@ -57,7 +57,7 @@ add_dependencies(vmlinux vmlinux-external)
 
 function (ebpf_probe_target target)
     set(options OPTIONAL GENSKELETON INSTALL)
-    set(multiValueArgs FLAGS SOURCES DEPENDENCIES PUBLIC_HEADERS FILES)
+    set(multiValueArgs FLAGS SOURCES DEPENDENCIES PUBLIC_HEADERS DEPENDS)
 
     cmake_parse_arguments(EBPF_PROBE "${options}" ""
         "${multiValueArgs}" ${ARGN})
@@ -85,7 +85,7 @@ function (ebpf_probe_target target)
         COMMAND ${EBPF_EXTERNAL_ENV_FLAGS} ${BPF_COMPILER_ENV} ${BPF_COMPILER} ${BPF_COMPILER_FLAGS} -MD -MF ${EBPF_PROBE_DEPFILE} ${EBPF_PROBE_FLAGS} -c ${EBPF_PROBE_SOURCES} -o ${OUT_FILE}
         COMMAND ${STRIP_CMD}
         COMMAND ${SKELETON_CMD}
-        DEPENDS ${EBPF_PROBE_FILES}
+        DEPENDS ${EBPF_PROBE_DEPENDS}
     )
 
     add_custom_target(${target}_Probe DEPENDS ${OUT_FILE} ${SKEL_FILE})


### PR DESCRIPTION
Previously, EbpfEvents.c.o and libEbpfEvents.a would not be rebuilt if probe source files were updated, likewise for host isolation libs. This PR make cmake aware of those sources and ensures a rebuild happens on changes to those files.
