### PR TITLE
Move BPF support-detection logic from endpoint to this repository

### DIFF
--- a/EXCLUSIONS.md
+++ b/EXCLUSIONS.md
@@ -1,5 +1,5 @@
 elastic/ebpf is tested against a matrix of kernels. The code contained in this
-repository is intended for use with linux kernel version 5.10.10 or higher,
+repository is intended for use with linux kernel version 5.10.16 or higher,
 with BTF (and other requisite configs) enabled.
 
 The following is a list of kernels where the ebpf programs fail to load or

--- a/GPL/Events/Process/Probe.bpf.c
+++ b/GPL/Events/Process/Probe.bpf.c
@@ -16,12 +16,6 @@
 #include "Helpers.h"
 #include "PathResolver.h"
 
-/* tty_write */
-DECL_FUNC_ARG(redirected_tty_write, iter);
-DECL_FUNC_ARG(redirected_tty_write, buf);
-DECL_FUNC_ARG(redirected_tty_write, count);
-DECL_FUNC_ARG_EXISTS(redirected_tty_write, iter);
-
 SEC("tp_btf/sched_process_fork")
 int BPF_PROG(sched_process_fork, const struct task_struct *parent, const struct task_struct *child)
 {
@@ -309,62 +303,21 @@ out:
 }
 
 SEC("fentry/tty_write")
-int BPF_PROG(fentry__tty_write)
+int BPF_PROG(fentry__tty_write, struct kiocb *iocb, struct iov_iter *from)
 {
-    const char *buf;
-    ssize_t count;
-    struct file *f;
-
-    if (FUNC_ARG_EXISTS(redirected_tty_write, iter)) {
-        struct iov_iter *ii = FUNC_ARG_READ(___type(ii), redirected_tty_write, iter);
-        buf                 = BPF_CORE_READ(ii, iov, iov_base);
-        count               = BPF_CORE_READ(ii, iov, iov_len);
-
-        struct kiocb *iocb = (struct kiocb *)ctx[0];
-        f                  = BPF_CORE_READ(iocb, ki_filp);
-    } else {
-        buf   = FUNC_ARG_READ(___type(buf), redirected_tty_write, buf);
-        count = FUNC_ARG_READ(___type(count), redirected_tty_write, count);
-
-        f = (struct file *)ctx[0];
-    }
+    const char *buf = BPF_CORE_READ(from, iov, iov_base);
+    ssize_t count   = BPF_CORE_READ(from, iov, iov_len);
+    struct file *f  = BPF_CORE_READ(iocb, ki_filp);
 
     return tty_write__enter(buf, count, f);
 }
 
 SEC("kprobe/tty_write")
-int BPF_KPROBE(kprobe__tty_write)
+int BPF_KPROBE(kprobe__tty_write, struct kiocb *iocb, struct iov_iter *from)
 {
-    const char *buf;
-    ssize_t count;
-    struct file *f;
-
-    if (FUNC_ARG_EXISTS(redirected_tty_write, iter)) {
-        struct iov_iter ii;
-        if (FUNC_ARG_READ_PTREGS(ii, redirected_tty_write, iter)) {
-            bpf_printk("kprobe__tty_write: error reading iov_iter\n");
-            goto out;
-        }
-        buf   = BPF_CORE_READ(ii.iov, iov_base);
-        count = BPF_CORE_READ(ii.iov, iov_len);
-
-        struct kiocb *iocb = (struct kiocb *)PT_REGS_PARM1(ctx);
-        f                  = BPF_CORE_READ(iocb, ki_filp);
-    } else {
-        if (FUNC_ARG_READ_PTREGS(buf, redirected_tty_write, buf)) {
-            bpf_printk("kprobe__tty_write: error reading buf\n");
-            goto out;
-        }
-        if (FUNC_ARG_READ_PTREGS(count, redirected_tty_write, count)) {
-            bpf_printk("kprobe__tty_write: error reading count\n");
-            goto out;
-        }
-
-        f = (struct file *)PT_REGS_PARM1(ctx);
-    }
+    const char *buf = BPF_CORE_READ(from, iov, iov_base);
+    ssize_t count   = BPF_CORE_READ(from, iov, iov_len);
+    struct file *f  = BPF_CORE_READ(iocb, ki_filp);
 
     return tty_write__enter(buf, count, f);
-
-out:
-    return 0;
 }

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ located under the `GPL/` directory while all non-GPL code is located under the
 
 ## Event Sourcing
 
-On newer kernels (5.10.10+), Elastic endpoint uses eBPF to source the various
+On newer kernels (5.10.16+), Elastic endpoint uses eBPF to source the various
 security events it ultimately sends up to an Elasticsearch cluster (e.g.
 process execution, file creation, file rename). On older kernels, this data is
 sourced via

--- a/non-GPL/Events/Lib/EbpfEvents.c
+++ b/non-GPL/Events/Lib/EbpfEvents.c
@@ -371,7 +371,7 @@ static bool system_supports_bpf_events(void)
     // We only support Linux 5.10.16+
     //
     // Linux commit e114dd64c0071500345439fc79dd5e0f9d106ed (went in in
-    // 5.11/5.10.16) fixed a verifier buf that (as of 9/28/2022) causes our
+    // 5.11/5.10.16) fixed a verifier bug that (as of 9/28/2022) causes our
     // probes to fail to load.
     //
     // Theoretically, we could push support back to 5.8 without any

--- a/non-GPL/Events/Lib/EbpfEvents.c
+++ b/non-GPL/Events/Lib/EbpfEvents.c
@@ -406,7 +406,7 @@ static bool system_supports_bpf_events(void)
 
     if (!features & EBPF_FEATURE_BPF_TRAMP) {
         // BPF trampolines are not supported, can we fallback to kprobes?
-        verbose("kernel does not support BPF trampolines, detecting kprobe support");
+        verbose("kernel does not support BPF trampolines, detecting kprobe support\n");
 
         if (!libbpf_probe_bpf_prog_type(BPF_PROG_TYPE_KPROBE, NULL)) {
             verbose("Kernel does not support BPF_PROG_TYPE_KPROBE, bpf events are not supported\n");

--- a/non-GPL/Events/Lib/EbpfEvents.c
+++ b/non-GPL/Events/Lib/EbpfEvents.c
@@ -404,8 +404,7 @@ static bool kernel_version_is_supported(void)
     }
 
     if (VERSION(maj, min, patch) < VERSION(5, 10, 16)) {
-        verbose("kernel version is < 5.10.16 (%d.%d.%d), bpf events are not supported\n", maj, min,
-                patch);
+        verbose("kernel version is < 5.10.16 (%s), bpf events are not supported\n", un.release);
         goto out;
     }
 #undef VERSION

--- a/non-GPL/Events/Lib/EbpfEvents.c
+++ b/non-GPL/Events/Lib/EbpfEvents.c
@@ -462,7 +462,7 @@ int ebpf_event_ctx__new(struct ebpf_event_ctx **ctx, ebpf_event_handler_fn cb, u
     struct btf *btf              = NULL;
 
     if (!system_supports_bpf_events()) {
-        verbose("this system does not support BPF (see logs)\n");
+        verbose("this system does not support BPF events (see logs)\n");
         return -ENOTSUP;
     }
 

--- a/non-GPL/Events/Lib/EbpfEvents.c
+++ b/non-GPL/Events/Lib/EbpfEvents.c
@@ -368,10 +368,10 @@ static bool system_has_btf(void)
     struct btf *btf = btf__load_vmlinux_btf();
     if (libbpf_get_error(btf)) {
         verbose("Kernel does not support BTF, bpf events are not supported\n");
-        return true;
+        return false;
     } else {
         btf__free(btf);
-        return false;
+        return true;
     }
 }
 

--- a/non-GPL/Events/Lib/EbpfEvents.h
+++ b/non-GPL/Events/Lib/EbpfEvents.h
@@ -24,15 +24,8 @@ struct ebpf_event_ctx;
 
 typedef int (*ebpf_event_handler_fn)(struct ebpf_event_header *);
 
-struct ebpf_event_ctx_opts {
-    uint64_t events;
-    uint64_t features;
-};
-
 /* Turn on logging of all libbpf debug logs to stderr */
 int ebpf_set_verbose_logging();
-
-int ebpf_detect_system_features(uint64_t *features);
 
 /* Allocates a new context based on requested events and capabilities.
  *
@@ -43,9 +36,9 @@ int ebpf_detect_system_features(uint64_t *features);
  * on success. Returns an error on failure. If ctx is NULL,
  * returns 0 on success or less than 0 on failure.
  */
-int ebpf_event_ctx__new(struct ebpf_event_ctx **ctx,
-                        ebpf_event_handler_fn cb,
-                        struct ebpf_event_ctx_opts opts);
+int ebpf_event_ctx__new(struct ebpf_event_ctx **ctx, ebpf_event_handler_fn cb, uint64_t events);
+
+uint64_t ebpf_event_ctx__get_features(struct ebpf_event_ctx *ctx);
 
 /* Consumes as many events as possible from the event context and returns the
  * number consumed.

--- a/testing/testrunner/eventstrace.go
+++ b/testing/testrunner/eventstrace.go
@@ -132,7 +132,7 @@ func (et *EventsTraceInstance) Stop() error {
 
 func NewEventsTrace(ctx context.Context, args ...string) *EventsTraceInstance {
 	var et EventsTraceInstance
-	args = append(args, "--print-features-on-init", "--unbuffer-stdout", "--libbpf-verbose", "--features-autodetect")
+	args = append(args, "--print-features-on-init", "--unbuffer-stdout", "--libbpf-verbose")
 	et.Cmd = exec.CommandContext(ctx, eventsTraceBinPath, args...)
 
 	stdout, err := et.Cmd.StdoutPipe()


### PR DESCRIPTION
Since the very beginning, the logic to detect if we support BPF (and all required BPF features) has been done in endpoint instead of in the ebpf events library. This is wonky. Logically, this logic belongs here, the library should be performing all necessary checks and returning `-ENOTSUP` if it can't load the probes. Library users shouldn't have to divine the specific system characteristics needed for the library to successfully run themselves.

This PR moves all the support-detection logic from endpoint to this repository, clarifies the minimum supported Linux version as 5.10.16 (not 5.10.10) and simplifies related feature detection logic. See commit messages for detailed explanations.
