### PR TITLE
[8.6] Fix clang-format breakage due to llvm 15 release (#163)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ BUILD_CONTAINER_IMAGE ?=
 
 CONTAINER_ENGINE ?= docker
 CONTAINER_REPOSITORY ?= ghcr.io/elastic/ebpf-builder
-CONTAINER_PULL_TAG ?= 20220731-1104
+CONTAINER_PULL_TAG ?= 20221121-1315
 CONTAINER_LOCAL_TAG ?= ebpf-builder:${USER}-latest
 
 IMAGEPACK_REPOSITORY ?= ghcr.io/elastic/ebpf-imagepack

--- a/docker/Dockerfile.builder
+++ b/docker/Dockerfile.builder
@@ -84,7 +84,7 @@ RUN printf "#!/bin/bash\nsource scl_source enable rh-python38\nexec pip3 \"\$@\"
     && chmod a+x /usr/bin/pip3
 
 # Install clang-format. Anything to not build/maintain clang/llvm.
-RUN python3 -m pip install --no-cache --upgrade pip clang-format
+RUN python3 -m pip install --no-cache --upgrade pip clang-format==14.0.6
 
 RUN printf "#!/bin/bash\nsource scl_source enable rh-python38\nexec clang-format \"\$@\"\n" > /usr/bin/clang-format \
     && chmod a+x /usr/bin/clang-format


### PR DESCRIPTION
Dockerfile update to workaround aarch64 install failures for clang-format 15.0.4 released on nov4