### PR TITLE
Align with libbpf function names

### DIFF
--- a/non-GPL/Events/EventsTrace/EventsTrace.c
+++ b/non-GPL/Events/EventsTrace/EventsTrace.c
@@ -797,7 +797,7 @@ int main(int argc, char **argv)
         print_init_msg(ebpf_event_ctx__get_features(ctx));
 
     while (!exiting) {
-        err = ebpf_event_ctx__poll(ctx, 10);
+        err = ebpf_event_ctx__next(ctx, 10);
         if (err < 0 && err != -EINTR) {
             fprintf(stderr, "Failed to poll event context %d: %s\n", err, strerror(-err));
             break;

--- a/non-GPL/Events/EventsTrace/EventsTrace.c
+++ b/non-GPL/Events/EventsTrace/EventsTrace.c
@@ -797,7 +797,7 @@ int main(int argc, char **argv)
         print_init_msg(ebpf_event_ctx__get_features(ctx));
 
     while (!exiting) {
-        err = ebpf_event_ctx__next(ctx, 10);
+        err = ebpf_event_ctx__poll(ctx, 10);
         if (err < 0 && err != -EINTR) {
             fprintf(stderr, "Failed to poll event context %d: %s\n", err, strerror(-err));
             break;

--- a/non-GPL/Events/Lib/EbpfEvents.c
+++ b/non-GPL/Events/Lib/EbpfEvents.c
@@ -654,12 +654,21 @@ out_destroy_probe:
     return err;
 }
 
-int ebpf_event_ctx__next(struct ebpf_event_ctx *ctx, int timeout)
+int ebpf_event_ctx__poll(struct ebpf_event_ctx *ctx, int timeout)
 {
     if (!ctx)
         return -1;
 
     int consumed = ring_buffer__poll(ctx->ringbuf, timeout);
+    return consumed > 0 ? 0 : consumed;
+}
+
+int ebpf_event_ctx__consume(struct ebpf_event_ctx *ctx)
+{
+    if (!ctx)
+        return -1;
+
+    int consumed = ring_buffer__consume(ctx->ringbuf);
     return consumed > 0 ? 0 : consumed;
 }
 

--- a/non-GPL/Events/Lib/EbpfEvents.c
+++ b/non-GPL/Events/Lib/EbpfEvents.c
@@ -654,7 +654,7 @@ out_destroy_probe:
     return err;
 }
 
-int ebpf_event_ctx__poll(struct ebpf_event_ctx *ctx, int timeout)
+int ebpf_event_ctx__next(struct ebpf_event_ctx *ctx, int timeout)
 {
     if (!ctx)
         return -1;
@@ -663,13 +663,20 @@ int ebpf_event_ctx__poll(struct ebpf_event_ctx *ctx, int timeout)
     return consumed > 0 ? 0 : consumed;
 }
 
+int ebpf_event_ctx__poll(struct ebpf_event_ctx *ctx, int timeout)
+{
+    if (!ctx)
+        return -1;
+
+    return ring_buffer__poll(ctx->ringbuf, timeout);
+}
+
 int ebpf_event_ctx__consume(struct ebpf_event_ctx *ctx)
 {
     if (!ctx)
         return -1;
 
-    int consumed = ring_buffer__consume(ctx->ringbuf);
-    return consumed > 0 ? 0 : consumed;
+    return ring_buffer__consume(ctx->ringbuf);
 }
 
 void ebpf_event_ctx__destroy(struct ebpf_event_ctx **ctx)

--- a/non-GPL/Events/Lib/EbpfEvents.h
+++ b/non-GPL/Events/Lib/EbpfEvents.h
@@ -41,9 +41,15 @@ int ebpf_event_ctx__new(struct ebpf_event_ctx **ctx, ebpf_event_handler_fn cb, u
 uint64_t ebpf_event_ctx__get_features(struct ebpf_event_ctx *ctx);
 
 /* Consumes as many events as possible from the event context and returns the
- * number consumed.
+ * number consumed. This will internally poll for events.
  */
-int ebpf_event_ctx__next(struct ebpf_event_ctx *ctx, int timeout);
+int ebpf_event_ctx__poll(struct ebpf_event_ctx *ctx, int timeout);
+
+/* Consumes as many events as possible from the event context and returns the
+ * number consumed. Does not poll. This is good if you are polling outside
+ * this library.
+ */
+int ebpf_event_ctx__consume(struct ebpf_event_ctx *ctx);
 
 void ebpf_event_ctx__destroy(struct ebpf_event_ctx **ctx);
 

--- a/non-GPL/Events/Lib/EbpfEvents.h
+++ b/non-GPL/Events/Lib/EbpfEvents.h
@@ -41,13 +41,24 @@ int ebpf_event_ctx__new(struct ebpf_event_ctx **ctx, ebpf_event_handler_fn cb, u
 uint64_t ebpf_event_ctx__get_features(struct ebpf_event_ctx *ctx);
 
 /* Consumes as many events as possible from the event context and returns the
- * number consumed. This will internally poll for events.
+ * number consumed.
+ *
+ * returns 0 on success, or less than 0 on failure
+ */
+int ebpf_event_ctx__next(struct ebpf_event_ctx *ctx, int timeout);
+
+/* Consumes as many events as possible from the event context and returns the
+ * number consumed.  This will internally poll for events.
+ *
+ * returns the number of events acted upon, or less than 0 on failure.
  */
 int ebpf_event_ctx__poll(struct ebpf_event_ctx *ctx, int timeout);
 
 /* Consumes as many events as possible from the event context and returns the
  * number consumed. Does not poll. This is good if you are polling outside
  * this library.
+ *
+ * returns the number of events acted upon, or less than 0 on failure.
  */
 int ebpf_event_ctx__consume(struct ebpf_event_ctx *ctx);
 


### PR DESCRIPTION
This PR exposes a *__consume function
And renames *__next to *__poll

The main idea here is to allow users to avoid a second polling call, if polling is done outside this library.