### PR TITLE
fix: failed byte off relocation for iov_iter.iov

### DIFF
--- a/GPL/Events/Process/Probe.bpf.c
+++ b/GPL/Events/Process/Probe.bpf.c
@@ -372,11 +372,12 @@ static int tty_write__enter(struct kiocb *iocb, struct iov_iter *from)
     }
 
     const struct iovec *iov;
-    if (FIELD_OFFSET(iov_iter, __iov)) {
+    if (FIELD_OFFSET(iov_iter, __iov))
         iov = (const struct iovec *)((char *)from + FIELD_OFFSET(iov_iter, __iov));
-    } else {
+    else if (bpf_core_field_exists(from->iov))
         iov = BPF_CORE_READ(from, iov);
-    }
+    else
+        goto out;
 
     u64 nr_segs = BPF_CORE_READ(from, nr_segs);
     nr_segs     = nr_segs > MAX_NR_SEGS ? MAX_NR_SEGS : nr_segs;


### PR DESCRIPTION
Fix probe load with veristat:

```
returning from callee:
 frame2: R0_w=scalar() R1_w=scalar(umax=16777215,var_off=(0x0; 0xffffff)) R2_w=scalar(umax=65535,var_off=(0x0; 0xffff)) R3_w=scalar(umax=65535,var_off=(0x0; 0xffff)) R4_w=scalar(umax=16777215,var_off=(0x0; 0xffffff)) R5_w=scalar(umax=65535,var_off=(0x0; 0xffff)) R6=fp-56 R7_w=scalar(id=18) R8=scalar(id=15) R10=fp0 fp-8_w=mmmmmmmm fp-16= fp-24_w=mmmmmmmm fp-32_w=mmmmmmmm fp-40_w=mmmmmmmm fp-48_w=mmmmmmmm fp-56_w=mmmmmmmm fp-64=????mmmm fp-72=mmmmmmmm fp-80=mmmmmmmm fp-88=mmmmmmmm fp-96=mmmmmmmm fp-104=mmmmmmmm
to caller at 91:
 frame1: R0_w=scalar() R6=scalar(id=1) R7=scalar(id=14) R8=scalar(id=14) R9=1 R10=fp0 fp-8=mmmmmmmm fp-16=mmmmmmmm fp-24=mmmmmmmm fp-32=mmmmmmmm fp-40=mmmmmmmm fp-48=mmmmmmmm fp-56=mmmmmmmm fp-64=mm??????
; if (slave.major == 0 && slave.minor == 0) {
91: (69) r1 = *(u16 *)(r10 -54)       ; frame1: R1_w=scalar(umax=65535,var_off=(0x0; 0xffff)) R10=fp0 fp-56=mmmmmmmm
; if (slave.major == 0 && slave.minor == 0) {
92: (55) if r1 != 0x0 goto pc+2       ; frame1: R1_w=0
; if (slave.major == 0 && slave.minor == 0) {
93: (69) r1 = *(u16 *)(r10 -56)       ; frame1: R1_w=scalar(umax=65535,var_off=(0x0; 0xffff)) R10=fp0 fp-56=mmmmmmmm
; if (slave.major == 0 && slave.minor == 0) {
94: (15) if r1 == 0x0 goto pc+79      ; frame1: R1_w=scalar(umax=65535,var_off=(0x0; 0xffff))
; if ((is_master && !(master.termios.c_lflag & ECHO)) && !(slave.termios.c_lflag & ECHO)) {
95: (15) if r9 == 0x0 goto pc+6       ; frame1: R9=1
; if ((is_master && !(master.termios.c_lflag & ECHO)) && !(slave.termios.c_lflag & ECHO)) {
96: (61) r1 = *(u32 *)(r10 -16)       ; frame1: R1_w=scalar(umax=4294967295,var_off=(0x0; 0xffffffff)) R10=fp0 fp-16=mmmmmmmm
; if ((is_master && !(master.termios.c_lflag & ECHO)) && !(slave.termios.c_lflag & ECHO)) {
97: (57) r1 &= 8                      ; frame1: R1_w=scalar(umax=8,var_off=(0x0; 0x8))
; if ((is_master && !(master.termios.c_lflag & ECHO)) && !(slave.termios.c_lflag & ECHO)) {
98: (55) if r1 != 0x0 goto pc+3       ; frame1: R1_w=0
; if ((is_master && !(master.termios.c_lflag & ECHO)) && !(slave.termios.c_lflag & ECHO)) {
99: (61) r1 = *(u32 *)(r10 -40)       ; frame1: R1_w=scalar(umax=4294967295,var_off=(0x0; 0xffffffff)) R10=fp0 fp-40=mmmmmmmm
; if ((is_master && !(master.termios.c_lflag & ECHO)) && !(slave.termios.c_lflag & ECHO)) {
100: (57) r1 &= 8                     ; frame1: R1=scalar(umax=8,var_off=(0x0; 0x8))
; if ((is_master && !(master.termios.c_lflag & ECHO)) && !(slave.termios.c_lflag & ECHO)) {
101: (15) if r1 == 0x0 goto pc+72     ; frame1: R1=scalar(umax=8,var_off=(0x0; 0x8))
; if (FIELD_OFFSET(iov_iter, __iov)) {
102: (18) r1 = 0xffff9bf540a2401c     ; frame1: R1_w=map_value(off=28,ks=4,vs=32,imm=0)
104: (61) r2 = *(u32 *)(r1 +0)        ; frame1: R1_w=map_value(off=28,ks=4,vs=32,imm=0) R2_w=0
; if (FIELD_OFFSET(iov_iter, __iov)) {
105: (15) if r2 == 0x0 goto pc+6      ; frame1: R2_w=0
; iov = (const struct iovec *)((char *)from + FIELD_OFFSET(iov_iter, __iov));
112: <invalid CO-RE relocation>
failed to resolve CO-RE relocation <byte_off> [1228] struct iov_iter.iov (0:4:0 @ offset 24)
verification time 1074 usec
stack depth 0+58+104+0+0
processed 375 insns (limit 1000000) max_states_per_insn 0 total_states 16 peak_states 16 mark_read 12

File              Program                              Verdict  Duration (us)  Insns  States  Peak states
----------------  -----------------------------------  -------  -------------  -----  ------  -----------
EventProbe.bpf.o  fentry__commit_creds                 success           2078    740      35           35
EventProbe.bpf.o  fentry__do_renameat2                 success            231     68       4            4
EventProbe.bpf.o  fentry__do_unlinkat                  success            158     50       2            2
EventProbe.bpf.o  fentry__mnt_want_write               success            135     37       3            3
EventProbe.bpf.o  fentry__taskstats_exit               success          93545  26453    1397           78
EventProbe.bpf.o  fentry__tcp_close                    success           1440    474      26           26
EventProbe.bpf.o  fentry__tty_write                    failure           1101    375      16           16
EventProbe.bpf.o  fentry__vfs_rename                   success         212153  79645    3119          405
EventProbe.bpf.o  fentry__vfs_unlink                   success            378    129       3            3
EventProbe.bpf.o  fexit__do_filp_open                  success         110020  40596    1595          205
EventProbe.bpf.o  fexit__inet_csk_accept               success           1226    419      25           25
EventProbe.bpf.o  fexit__tcp_v4_connect                success           1243    422      25           25
EventProbe.bpf.o  fexit__tcp_v6_connect                success           1270    422      25           25
EventProbe.bpf.o  fexit__vfs_rename                    success           1817    652      20           20
EventProbe.bpf.o  fexit__vfs_unlink                    success         108347  40604    1596          206
EventProbe.bpf.o  kprobe__commit_creds                 success           2103    740      35           35
EventProbe.bpf.o  kprobe__do_renameat2                 success            213     68       4            4
EventProbe.bpf.o  kprobe__do_unlinkat                  success            154     50       2            2
EventProbe.bpf.o  kprobe__mnt_want_write               success            294     37       3            3
EventProbe.bpf.o  kprobe__taskstats_exit               success          93710  26453    1397           78
EventProbe.bpf.o  kprobe__tcp_close                    success           1507    474      26           26
EventProbe.bpf.o  kprobe__tcp_v4_connect               success            158     50       2            2
EventProbe.bpf.o  kprobe__tcp_v6_connect               success            157     50       2            2
EventProbe.bpf.o  kprobe__tty_write                    failure           1074    375      16           16
EventProbe.bpf.o  kprobe__vfs_rename                   success         211922  78817    3080          424
EventProbe.bpf.o  kprobe__vfs_unlink                   success            382    124       4            4
EventProbe.bpf.o  kretprobe__do_filp_open              success         110403  40596    1595          205
EventProbe.bpf.o  kretprobe__inet_csk_accept           success           1201    419      25           25
EventProbe.bpf.o  kretprobe__tcp_v4_connect            success           1281    432      26           26
EventProbe.bpf.o  kretprobe__tcp_v6_connect            success           1414    432      26           26
EventProbe.bpf.o  kretprobe__vfs_rename                success           1733    641      19           19
EventProbe.bpf.o  kretprobe__vfs_unlink                success         111057  40593    1595          205
EventProbe.bpf.o  sched_process_exec                   success         218171  67486    2987          292
EventProbe.bpf.o  sched_process_fork                   success          93940  26868    1416           99
EventProbe.bpf.o  tracepoint_syscalls_sys_exit_setsid  success            737    262      14           14
----------------  -----------------------------------  -------  -------------  -----  ------  -----------
Done. Processed 1 files, 0 programs. Skipped 35 files, 0 programs.
```

```
File              Program                              Verdict  Duration (us)  Insns  States  Peak states
----------------  -----------------------------------  -------  -------------  -----  ------  -----------
EventProbe.bpf.o  fentry__commit_creds                 success           1886    740      35           35
EventProbe.bpf.o  fentry__do_renameat2                 success            219     68       4            4
EventProbe.bpf.o  fentry__do_unlinkat                  success            159     50       2            2
EventProbe.bpf.o  fentry__mnt_want_write               success            142     37       3            3
EventProbe.bpf.o  fentry__taskstats_exit               success          83538  26453    1397           78
EventProbe.bpf.o  fentry__tcp_close                    success           1383    474      26           26
EventProbe.bpf.o  fentry__tty_write                    success          34397  14141     241          190
EventProbe.bpf.o  fentry__vfs_rename                   success         196173  79645    3119          405
EventProbe.bpf.o  fentry__vfs_unlink                   success            360    129       3            3
EventProbe.bpf.o  fexit__do_filp_open                  success         100397  40596    1595          205
EventProbe.bpf.o  fexit__inet_csk_accept               success           1159    419      25           25
EventProbe.bpf.o  fexit__tcp_v4_connect                success           1181    422      25           25
EventProbe.bpf.o  fexit__tcp_v6_connect                success           1170    422      25           25
EventProbe.bpf.o  fexit__vfs_rename                    success           1702    652      20           20
EventProbe.bpf.o  fexit__vfs_unlink                    success         102075  40604    1596          206
EventProbe.bpf.o  kprobe__commit_creds                 success           1851    740      35           35
EventProbe.bpf.o  kprobe__do_renameat2                 success            209     68       4            4
EventProbe.bpf.o  kprobe__do_unlinkat                  success            160     50       2            2
EventProbe.bpf.o  kprobe__mnt_want_write               success            118     37       3            3
EventProbe.bpf.o  kprobe__taskstats_exit               success          83611  26453    1397           78
EventProbe.bpf.o  kprobe__tcp_close                    success           1302    474      26           26
EventProbe.bpf.o  kprobe__tcp_v4_connect               success            148     50       2            2
EventProbe.bpf.o  kprobe__tcp_v6_connect               success            144     50       2            2
EventProbe.bpf.o  kprobe__tty_write                    success          34174  14141     241          190
EventProbe.bpf.o  kprobe__vfs_rename                   success         192791  78817    3080          424
EventProbe.bpf.o  kprobe__vfs_unlink                   success            343    124       4            4
EventProbe.bpf.o  kretprobe__do_filp_open              success         100998  40596    1595          205
EventProbe.bpf.o  kretprobe__inet_csk_accept           success           1335    419      25           25
EventProbe.bpf.o  kretprobe__tcp_v4_connect            success           1183    432      26           26
EventProbe.bpf.o  kretprobe__tcp_v6_connect            success           1224    432      26           26
EventProbe.bpf.o  kretprobe__vfs_rename                success           1673    641      19           19
EventProbe.bpf.o  kretprobe__vfs_unlink                success         101434  40593    1595          205
EventProbe.bpf.o  sched_process_exec                   success         194325  67486    2987          292
EventProbe.bpf.o  sched_process_fork                   success          83324  26868    1416           99
EventProbe.bpf.o  tracepoint_syscalls_sys_exit_setsid  success            683    262      14           14
----------------  -----------------------------------  -------  -------------  -----  ------  -----------
Done. Processed 1 files, 0 programs. Skipped 35 files, 0 programs.
```