### PR TITLE
fix: dereference of modified ctx ptr with clang16

### DIFF
--- a/GPL/Events/State.h
+++ b/GPL/Events/State.h
@@ -32,7 +32,7 @@ enum ebpf_events_unlink_state_step {
 struct ebpf_events_unlink_state {
     enum ebpf_events_unlink_state_step step;
     struct vfsmount *mnt;
-    struct dentry de;
+    struct dentry *de;
 };
 
 enum ebpf_events_rename_state_step {


### PR DESCRIPTION
When compiling `EventProbe` with clang-16 and loading it both with a Go loader and veristat, there's a verifier error:

```
libbpf: prog 'kprobe__vfs_unlink': BPF program load failed: Permission denied
libbpf: prog 'kprobe__vfs_unlink': failed to load: -13
libbpf: failed to load object 'bpf_bpfel_x86.o'
PROCESSING bpf_bpfel_x86.o/kprobe__vfs_unlink, DURATION US: 46, VERDICT: failure, VERIFIER LOG:
0: R1=ctx(off=0,imm=0) R10=fp0
; int err = FUNC_ARG_READ_PTREGS(de, vfs_unlink, dentry);
0: (18) r2 = 0xffff9bf5409ba004       ; R2_w=map_value(off=4,ks=4,vs=32,imm=0)
2: (61) r2 = *(u32 *)(r2 +0)          ; R2_w=0
3: (65) if r2 s> 0x1 goto pc+5        ; R2_w=0
4: (15) if r2 == 0x0 goto pc+10       ; R2_w=0
15: (b7) r2 = 112                     ; R2_w=112
16: (05) goto pc+3
20: (0f) r1 += r2                     ; R1_w=ctx(off=112,imm=0) R2_w=112
; int err = FUNC_ARG_READ_PTREGS(de, vfs_unlink, dentry);
21: (79) r3 = *(u64 *)(r1 +0)
dereference of modified ctx ptr R1 off=112 disallowed
verification time 46 usec
stack depth 0
processed 8 insns (limit 1000000) max_states_per_insn 0 total_states 0 peak_states 0 mark_read 0
```