### PR TITLE
EventProbe: capture file info from inode

### DIFF
--- a/GPL/Events/EbpfEventProto.h
+++ b/GPL/Events/EbpfEventProto.h
@@ -55,6 +55,7 @@ enum ebpf_varlen_field_type {
     EBPF_VL_FIELD_NEW_PATH,
     EBPF_VL_FIELD_TTY_OUT,
     EBPF_VL_FIELD_PIDS_SS_CGROUP_PATH,
+    EBPF_VL_FIELD_SYMLINK_TARGET_PATH,
 };
 
 // Convenience macro to iterate all the variable length fields in an event
@@ -117,34 +118,54 @@ struct ebpf_tty_dev {
     struct ebpf_tty_termios termios;
 } __attribute__((packed));
 
+enum ebpf_file_type {
+    EBPF_FILE_TYPE_FILE    = 1,
+    EBPF_FILE_TYPE_DIR     = 2,
+    EBPF_FILE_TYPE_SYMLINK = 3,
+};
+
+struct ebpf_file_info {
+    enum ebpf_file_type type;
+    uint64_t inode;
+    uint16_t mode;
+    uint64_t size;
+    uint32_t uid;
+    uint32_t gid;
+    uint64_t mtime;
+    uint64_t ctime;
+} __attribute__((packed));
+
 // Full events follow
 struct ebpf_file_delete_event {
     struct ebpf_event_header hdr;
     struct ebpf_pid_info pids;
+    struct ebpf_file_info finfo;
     uint32_t mntns;
     char comm[TASK_COMM_LEN];
 
-    // Variable length fields: path
+    // Variable length fields: path, symlink_target_path
     struct ebpf_varlen_fields_start vl_fields;
 } __attribute__((packed));
 
 struct ebpf_file_create_event {
     struct ebpf_event_header hdr;
     struct ebpf_pid_info pids;
+    struct ebpf_file_info finfo;
     uint32_t mntns;
     char comm[TASK_COMM_LEN];
 
-    // Variable length fields: path
+    // Variable length fields: path, symlink_target_path
     struct ebpf_varlen_fields_start vl_fields;
 } __attribute__((packed));
 
 struct ebpf_file_rename_event {
     struct ebpf_event_header hdr;
     struct ebpf_pid_info pids;
+    struct ebpf_file_info finfo;
     uint32_t mntns;
     char comm[TASK_COMM_LEN];
 
-    // Variable length fields: old_path, new_path
+    // Variable length fields: old_path, new_path, symlink_target_path
     struct ebpf_varlen_fields_start vl_fields;
 } __attribute__((packed));
 

--- a/GPL/Events/File/File.h
+++ b/GPL/Events/File/File.h
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: GPL-2.0-only OR BSD-2-Clause
+
+/*
+ * Copyright (C) 2021 Elasticsearch BV
+ *
+ * This software is dual-licensed under the BSD 2-Clause and GPL v2 licenses.
+ * You may choose either one of them if you use this software.
+ */
+
+#ifndef EBPF_EVENTPROBE_FILE_H
+#define EBPF_EVENTPROBE_FILE_H
+
+#include "EbpfEventProto.h"
+
+#define PATH_MAX 4096
+
+// include/uapi/linux/stat.h
+#define S_IFMT 00170000
+#define S_IFSOCK 0140000
+#define S_IFLNK 0120000
+#define S_IFREG 0100000
+#define S_IFBLK 0060000
+#define S_IFDIR 0040000
+#define S_IFCHR 0020000
+#define S_IFIFO 0010000
+#define S_ISUID 0004000
+#define S_ISGID 0002000
+#define S_ISVTX 0001000
+
+#define S_ISLNK(m) (((m)&S_IFMT) == S_IFLNK)
+#define S_ISREG(m) (((m)&S_IFMT) == S_IFREG)
+#define S_ISDIR(m) (((m)&S_IFMT) == S_IFDIR)
+#define S_ISCHR(m) (((m)&S_IFMT) == S_IFCHR)
+#define S_ISBLK(m) (((m)&S_IFMT) == S_IFBLK)
+#define S_ISFIFO(m) (((m)&S_IFMT) == S_IFIFO)
+#define S_ISSOCK(m) (((m)&S_IFMT) == S_IFSOCK)
+
+#define S_IRWXU 00700
+#define S_IRUSR 00400
+#define S_IWUSR 00200
+#define S_IXUSR 00100
+
+#define S_IRWXG 00070
+#define S_IRGRP 00040
+#define S_IWGRP 00020
+#define S_IXGRP 00010
+
+#define S_IRWXO 00007
+#define S_IROTH 00004
+#define S_IWOTH 00002
+#define S_IXOTH 00001
+
+static int ebpf_file_info__fill(struct ebpf_file_info *finfo, struct dentry *de)
+{
+    struct inode *ino = BPF_CORE_READ(de, d_inode);
+
+    finfo->inode = BPF_CORE_READ(ino, i_ino);
+    finfo->mode  = BPF_CORE_READ(ino, i_mode);
+    finfo->size  = BPF_CORE_READ(ino, i_size);
+    finfo->uid   = BPF_CORE_READ(ino, i_uid.val);
+    finfo->gid   = BPF_CORE_READ(ino, i_gid.val);
+    finfo->mtime = BPF_CORE_READ(ino, i_mtime.tv_nsec);
+    finfo->ctime = BPF_CORE_READ(ino, i_ctime.tv_nsec);
+
+    if (S_ISREG(finfo->mode)) {
+        finfo->type = EBPF_FILE_TYPE_FILE;
+    } else if (S_ISDIR(finfo->mode)) {
+        finfo->type = EBPF_FILE_TYPE_DIR;
+    } else if (S_ISLNK(finfo->mode)) {
+        finfo->type = EBPF_FILE_TYPE_SYMLINK;
+    } else {
+        bpf_printk("unknown file type (mode=%d)", finfo->mode);
+        return -1;
+    }
+
+    return 0;
+}
+
+#endif // EBPF_EVENTPROBE_FILE_H

--- a/GPL/Events/State.h
+++ b/GPL/Events/State.h
@@ -32,7 +32,10 @@ enum ebpf_events_unlink_state_step {
 struct ebpf_events_unlink_state {
     enum ebpf_events_unlink_state_step step;
     struct vfsmount *mnt;
-    struct dentry *de;
+    // NOTE: for this specific hook, storing a dentry pointer
+    // doesn't work because the content will be emptied out
+    // in the exit function.
+    struct dentry de;
 };
 
 enum ebpf_events_rename_state_step {
@@ -44,6 +47,7 @@ enum ebpf_events_rename_state_step {
 struct ebpf_events_rename_state {
     enum ebpf_events_rename_state_step step;
     struct vfsmount *mnt;
+    struct dentry *de;
 };
 
 struct ebpf_events_tcp_connect_state {


### PR DESCRIPTION
tested manually (eventstrace):

```
{"event_type":"FILE_CREATE","pids":{"tid":3874,"tgid":3813,"ppid":2956,"pgid":2956,"sid":2956,"start_time_ns":50065645985},"mount_namespace":4026531841,"comm":"Cache2 I/O","file_info":{"type":"FILE","inode":48667076,"mode":100600,"size":0,"uid":1000,"gid":1000,"mtime":493949622,"ctime":493949622},"path":"/home/matt/.cache/mozilla/firefox/lpqgi4lp.default-release/cache2/entries/080AE6076F29C7973BFF7A893740046655644EBE","symlink_target_path":""}
{"event_type":"FILE_DELETE","pids":{"tid":777527,"tgid":777527,"ppid":13733,"pgid":777527,"sid":777527,"start_time_ns":181390102798979},"mount_namespace":4026531841,"comm":"zsh","file_info":{"type":"SYMLINK","inode":48667077,"mode":120777,"size":23,"uid":1000,"gid":1000,"mtime":773993000,"ctime":774993006},"path":"/home/matt/.zsh_history.LOCK","symlink_target_path":""}
{"event_type":"FILE_DELETE","pids":{"tid":979918,"tgid":979918,"ppid":777527,"pgid":979918,"sid":777527,"start_time_ns":231767498246356},"mount_namespace":4026531841,"comm":"rm","file_info":{"type":"SYMLINK","inode":6706,"mode":120777,"size":11,"uid":1000,"gid":1000,"mtime":241817035,"ctime":776993018},"path":"/tmp/ciao124","symlink_target_path":"/tmp/ciao123"}
```

draft: this temporarily reintroduces this bug: https://github.com/elastic/ebpf/commit/039ceef2f91a1c667319a211830692b487c1cda2 ; can be merged after I find a workaround