### PR TITLE
EventProbe: add file modification events

### DIFF
--- a/GPL/Events/EbpfEventProto.h
+++ b/GPL/Events/EbpfEventProto.h
@@ -29,9 +29,10 @@ enum ebpf_event_type {
     EBPF_EVENT_FILE_DELETE                  = (1 << 8),
     EBPF_EVENT_FILE_CREATE                  = (1 << 9),
     EBPF_EVENT_FILE_RENAME                  = (1 << 10),
-    EBPF_EVENT_NETWORK_CONNECTION_ACCEPTED  = (1 << 11),
-    EBPF_EVENT_NETWORK_CONNECTION_ATTEMPTED = (1 << 12),
-    EBPF_EVENT_NETWORK_CONNECTION_CLOSED    = (1 << 13),
+    EBPF_EVENT_FILE_MODIFY                  = (1 << 11),
+    EBPF_EVENT_NETWORK_CONNECTION_ACCEPTED  = (1 << 12),
+    EBPF_EVENT_NETWORK_CONNECTION_ATTEMPTED = (1 << 13),
+    EBPF_EVENT_NETWORK_CONNECTION_CLOSED    = (1 << 14),
 };
 
 struct ebpf_event_header {
@@ -172,6 +173,25 @@ struct ebpf_file_rename_event {
     char comm[TASK_COMM_LEN];
 
     // Variable length fields: old_path, new_path, symlink_target_path
+    struct ebpf_varlen_fields_start vl_fields;
+} __attribute__((packed));
+
+enum ebpf_file_change_type {
+    EBPF_FILE_CHANGE_TYPE_UNKNOWN     = 0,
+    EBPF_FILE_CHANGE_TYPE_CONTENT     = 1,
+    EBPF_FILE_CHANGE_TYPE_PERMISSIONS = 2,
+    EBPF_FILE_CHANGE_TYPE_XATTRS      = 3,
+};
+
+struct ebpf_file_modify_event {
+    struct ebpf_event_header hdr;
+    struct ebpf_pid_info pids;
+    struct ebpf_file_info finfo;
+    enum ebpf_file_change_type change_type;
+    uint32_t mntns;
+    char comm[TASK_COMM_LEN];
+
+    // Variable length fields: path, symlink_target_path
     struct ebpf_varlen_fields_start vl_fields;
 } __attribute__((packed));
 

--- a/GPL/Events/State.h
+++ b/GPL/Events/State.h
@@ -16,6 +16,7 @@ enum ebpf_events_state_op {
     EBPF_EVENTS_STATE_RENAME         = 2,
     EBPF_EVENTS_STATE_TCP_V4_CONNECT = 3,
     EBPF_EVENTS_STATE_TCP_V6_CONNECT = 4,
+    EBPF_EVENTS_STATE_CHMOD          = 5,
 };
 
 struct ebpf_events_key {
@@ -54,12 +55,18 @@ struct ebpf_events_tcp_connect_state {
     struct sock *sk;
 };
 
+struct ebpf_events_chmod_state {
+    struct path *path;
+    umode_t mode;
+};
+
 struct ebpf_events_state {
     union {
         struct ebpf_events_unlink_state unlink;
         struct ebpf_events_rename_state rename;
         struct ebpf_events_tcp_connect_state tcp_v4_connect;
         struct ebpf_events_tcp_connect_state tcp_v6_connect;
+        struct ebpf_events_chmod_state chmod;
     };
 };
 

--- a/non-GPL/Events/Lib/EbpfEvents.c
+++ b/non-GPL/Events/Lib/EbpfEvents.c
@@ -356,6 +356,8 @@ static inline int probe_set_autoload(struct btf *btf, struct EventProbe_bpf *obj
         err = err ?: bpf_program__set_autoload(obj->progs.kprobe__tcp_v4_connect, false);
         err = err ?: bpf_program__set_autoload(obj->progs.kretprobe__tcp_v4_connect, false);
         err = err ?: bpf_program__set_autoload(obj->progs.kprobe__tcp_close, false);
+        err = err ?: bpf_program__set_autoload(obj->progs.kprobe__chmod_common, false);
+        err = err ?: bpf_program__set_autoload(obj->progs.kretprobe__chmod_common, false);
     } else {
         err = err ?: bpf_program__set_autoload(obj->progs.fentry__do_unlinkat, false);
         err = err ?: bpf_program__set_autoload(obj->progs.fentry__mnt_want_write, false);
@@ -369,6 +371,7 @@ static inline int probe_set_autoload(struct btf *btf, struct EventProbe_bpf *obj
         err = err ?: bpf_program__set_autoload(obj->progs.fexit__inet_csk_accept, false);
         err = err ?: bpf_program__set_autoload(obj->progs.fexit__tcp_v4_connect, false);
         err = err ?: bpf_program__set_autoload(obj->progs.fentry__tcp_close, false);
+        err = err ?: bpf_program__set_autoload(obj->progs.fexit__chmod_common, false);
     }
 
     return err;

--- a/testing/test_bins/create_rename_delete_file.c
+++ b/testing/test_bins/create_rename_delete_file.c
@@ -8,6 +8,7 @@
  */
 
 #include <stdio.h>
+#include <sys/stat.h>
 #include <sys/types.h>
 #include <unistd.h>
 
@@ -28,6 +29,7 @@ int main()
 
     CHECK(fclose(f), EOF);
     CHECK(rename(filename_orig, filename_new), -1);
+    CHECK(chmod(filename_new, S_IRWXU | S_IRWXG | S_IRWXO), -1);
     CHECK(unlink(filename_new), -1);
 
     return 0;

--- a/testing/testrunner/utils.go
+++ b/testing/testrunner/utils.go
@@ -117,6 +117,13 @@ type FileDeleteEvent struct {
 	Finfo FileInfo `json:"file_info"`
 }
 
+type FileModifyEvent struct {
+	Pids       PidInfo  `json:"pids"`
+	Path       string   `json:"path"`
+	ChangeType string   `json:"change_type"`
+	Finfo      FileInfo `json:"file_info"`
+}
+
 type FileRenameEvent struct {
 	Pids    PidInfo  `json:"pids"`
 	OldPath string   `json:"old_path"`


### PR DESCRIPTION
Veristat output:

```Processing 'EventProbe.bpf.o'...
File              Program                              Verdict  Duration (us)  Insns  States  Peak states
----------------  -----------------------------------  -------  -------------  -----  ------  -----------
EventProbe.bpf.o  fentry__commit_creds                 success            331    740      35           35
EventProbe.bpf.o  fentry__do_renameat2                 success             71     68       4            4
EventProbe.bpf.o  fentry__do_unlinkat                  success             55     50       2            2
EventProbe.bpf.o  fentry__mnt_want_write               success             60     37       3            3
EventProbe.bpf.o  fentry__taskstats_exit               success          20725  26453    1397           78
EventProbe.bpf.o  fentry__tcp_close                    success            302    474      26           26
EventProbe.bpf.o  fentry__tty_write                    success            318    561      25           25
EventProbe.bpf.o  fentry__vfs_rename                   success          39680  79651    3119          405
EventProbe.bpf.o  fentry__vfs_unlink                   success             54     37       3            3
EventProbe.bpf.o  fexit__chmod_common                  success          20804  39540    1560          243
EventProbe.bpf.o  fexit__do_filp_open                  success          20830  40449    1573          244
EventProbe.bpf.o  fexit__inet_csk_accept               success            265    419      25           25
EventProbe.bpf.o  fexit__tcp_v4_connect                success            258    422      25           25
EventProbe.bpf.o  fexit__tcp_v6_connect                success            257    422      25           25
EventProbe.bpf.o  fexit__vfs_rename                    success            523   1309      42           42
EventProbe.bpf.o  fexit__vfs_unlink                    success          22484  40420    1571          243
EventProbe.bpf.o  kprobe__chmod_common                 success             33     43       1            1
EventProbe.bpf.o  kprobe__commit_creds                 success            319    740      35           35
EventProbe.bpf.o  kprobe__do_renameat2                 success             56     68       4            4
EventProbe.bpf.o  kprobe__do_unlinkat                  success             42     50       2            2
EventProbe.bpf.o  kprobe__mnt_want_write               success             41     37       3            3
EventProbe.bpf.o  kprobe__taskstats_exit               success          20921  26453    1397           78
EventProbe.bpf.o  kprobe__tcp_close                    success            292    474      26           26
EventProbe.bpf.o  kprobe__tcp_v4_connect               success             50     50       2            2
EventProbe.bpf.o  kprobe__tcp_v6_connect               success             45     50       2            2
EventProbe.bpf.o  kprobe__tty_write                    success            300    561      25           25
EventProbe.bpf.o  kprobe__vfs_rename                   success          41809  79648    3120          406
EventProbe.bpf.o  kprobe__vfs_unlink                   success             43     39       4            4
EventProbe.bpf.o  kretprobe__chmod_common              success          21164  39551    1561          244
EventProbe.bpf.o  kretprobe__do_filp_open              success          20861  40449    1573          244
EventProbe.bpf.o  kretprobe__inet_csk_accept           success            246    419      25           25
EventProbe.bpf.o  kretprobe__tcp_v4_connect            success            267    432      26           26
EventProbe.bpf.o  kretprobe__tcp_v6_connect            success            261    432      26           26
EventProbe.bpf.o  kretprobe__vfs_rename                success            506   1298      41           41
EventProbe.bpf.o  kretprobe__vfs_unlink                success          22073  40409    1570          242
EventProbe.bpf.o  sched_process_exec                   success          40250  67486    2987          292
EventProbe.bpf.o  sched_process_fork                   success          18328  26868    1416           99
EventProbe.bpf.o  tracepoint_syscalls_sys_exit_setsid  success            146    262      14           14
----------------  -----------------------------------  -------  -------------  -----  ------  -----------
Done. Processed 1 files, 0 programs. Skipped 38 files, 0 programs.
```

Tested manually:
```
{"probes_initialized": true, "features": {"bpf_tramp": true}}
{"event_type":"FILE_MODIFY","pids":{"tid":3020316,"tgid":3020316,"ppid":3014701,"pgid":3020316,"sid":3014701,"start_time_ns":1507556923658071},"mount_namespace":4026531841,"comm":"chmod","change_type":"PERMISSIONS","file_info":{"type":"FILE","inode":252659,"mode":100755,"size":0,"uid":1000,"gid":1000,"atime":1703253982613656962,"mtime":1703253982613656962,"ctime":1703255053237977655},"path":"/tmp/test123","symlink_target_path":""}
^CReceived SIGINT, exiting...
```

TODO: tests

Other file modification triggers (truncate, setxattr) will be handled in separate PRs