### PR TITLE
file events: add creds info

### DIFF
--- a/GPL/Events/EbpfEventProto.h
+++ b/GPL/Events/EbpfEventProto.h
@@ -146,6 +146,7 @@ struct ebpf_file_info {
 struct ebpf_file_delete_event {
     struct ebpf_event_header hdr;
     struct ebpf_pid_info pids;
+    struct ebpf_cred_info creds;
     struct ebpf_file_info finfo;
     uint32_t mntns;
     char comm[TASK_COMM_LEN];
@@ -157,6 +158,7 @@ struct ebpf_file_delete_event {
 struct ebpf_file_create_event {
     struct ebpf_event_header hdr;
     struct ebpf_pid_info pids;
+    struct ebpf_cred_info creds;
     struct ebpf_file_info finfo;
     uint32_t mntns;
     char comm[TASK_COMM_LEN];
@@ -168,6 +170,7 @@ struct ebpf_file_create_event {
 struct ebpf_file_rename_event {
     struct ebpf_event_header hdr;
     struct ebpf_pid_info pids;
+    struct ebpf_cred_info creds;
     struct ebpf_file_info finfo;
     uint32_t mntns;
     char comm[TASK_COMM_LEN];
@@ -187,6 +190,7 @@ enum ebpf_file_change_type {
 struct ebpf_file_modify_event {
     struct ebpf_event_header hdr;
     struct ebpf_pid_info pids;
+    struct ebpf_cred_info creds;
     struct ebpf_file_info finfo;
     enum ebpf_file_change_type change_type;
     uint32_t mntns;

--- a/GPL/Events/File/Probe.bpf.c
+++ b/GPL/Events/File/Probe.bpf.c
@@ -125,6 +125,7 @@ static int vfs_unlink__exit(int ret)
     event->hdr.type = EBPF_EVENT_FILE_DELETE;
     event->hdr.ts   = bpf_ktime_get_ns();
     ebpf_pid_info__fill(&event->pids, task);
+    ebpf_cred_info__fill(&event->creds, task);
 
     struct path p;
     p.dentry     = &state->unlink.de;
@@ -236,6 +237,7 @@ static int do_filp_open__exit(struct file *f)
         struct task_struct *task = (struct task_struct *)bpf_get_current_task();
         struct path p            = BPF_CORE_READ(f, f_path);
         ebpf_pid_info__fill(&event->pids, task);
+        ebpf_cred_info__fill(&event->creds, task);
         event->mntns = mntns(task);
         bpf_get_current_comm(event->comm, TASK_COMM_LEN);
         ebpf_file_info__fill(&event->finfo, p.dentry);
@@ -416,6 +418,7 @@ static int vfs_rename__exit(int ret)
     event->hdr.type = EBPF_EVENT_FILE_RENAME;
     event->hdr.ts   = bpf_ktime_get_ns();
     ebpf_pid_info__fill(&event->pids, task);
+    ebpf_cred_info__fill(&event->creds, task);
     event->mntns = mntns(task);
     bpf_get_current_comm(event->comm, TASK_COMM_LEN);
     ebpf_file_info__fill(&event->finfo, de);
@@ -479,6 +482,7 @@ static void file_modify_event__emit(enum ebpf_file_change_type typ, struct path 
     event->hdr.ts      = bpf_ktime_get_ns();
     event->change_type = typ;
     ebpf_pid_info__fill(&event->pids, task);
+    ebpf_cred_info__fill(&event->creds, task);
     event->mntns = mntns(task);
     bpf_get_current_comm(event->comm, TASK_COMM_LEN);
     struct dentry *d = BPF_CORE_READ(path, dentry);

--- a/non-GPL/Events/EventsTrace/EventsTrace.c
+++ b/non-GPL/Events/EventsTrace/EventsTrace.c
@@ -403,6 +403,9 @@ static void out_file_delete(struct ebpf_file_delete_event *evt)
     out_pid_info("pids", &evt->pids);
     out_comma();
 
+    out_cred_info("creds", &evt->creds);
+    out_comma();
+
     out_int("mount_namespace", evt->mntns);
     out_comma();
 
@@ -441,6 +444,9 @@ static void out_file_create(struct ebpf_file_create_event *evt)
     out_pid_info("pids", &evt->pids);
     out_comma();
 
+    out_cred_info("creds", &evt->creds);
+    out_comma();
+
     out_int("mount_namespace", evt->mntns);
     out_comma();
 
@@ -477,6 +483,9 @@ static void out_file_rename(struct ebpf_file_rename_event *evt)
     out_comma();
 
     out_pid_info("pids", &evt->pids);
+    out_comma();
+
+    out_cred_info("creds", &evt->creds);
     out_comma();
 
     out_int("mount_namespace", evt->mntns);
@@ -518,6 +527,9 @@ static void out_file_modify(struct ebpf_file_modify_event *evt)
     out_comma();
 
     out_pid_info("pids", &evt->pids);
+    out_comma();
+
+    out_cred_info("creds", &evt->creds);
     out_comma();
 
     out_int("mount_namespace", evt->mntns);


### PR DESCRIPTION
Tested manually

```
➜  ebpf git:(matt/file-creds) ✗ sudo ./artifacts-x86_64/non-GPL/Events/EventsTrace/EventsTrace -i --file-create
{"probes_initialized": true, "features": {"bpf_tramp": true}}
{"event_type":"FILE_CREATE","pids":{"tid":2639926,"tgid":2318768,"ppid":3224,"pgid":3224,"sid":3224,"start_time_ns":538596506094300},"creds":{"ruid":1000,"rgid":1000,"euid":1000,"egid":1000,"suid":1000,"sgid":1000,"cap_permitted": "0","cap_effective": "0"},"mount_namespace":4026531841,"comm":"BgIOThr~ol #233","file_info":{"type":"FILE","inode":56644481,"mode":100644,"size":0,"uid":1000,"gid":1000,"atime":1709316588121009722,"mtime":1709316588121009722,"ctime":1709316588121009722},"path":"/home/matt/.mozilla/firefox/lpqgi4lp.default-release/sessionstore-backups/recovery.jsonlz4.tmp","symlink_target_path":""}
^CReceived SIGINT, exiting...
➜  ebpf git:(matt/file-creds) ✗ sudo ../veristat/src/veristat ./artifacts-x86_64/GPL/Events/EventProbe.bpf.o   
Processing 'EventProbe.bpf.o'...
File              Program                              Verdict  Duration (us)  Insns  States  Peak states
----------------  -----------------------------------  -------  -------------  -----  ------  -----------
EventProbe.bpf.o  fentry__commit_creds                 success            336    740      35           35
EventProbe.bpf.o  fentry__do_renameat2                 success             73     68       4            4
EventProbe.bpf.o  fentry__do_unlinkat                  success             57     50       2            2
EventProbe.bpf.o  fentry__mnt_want_write               success             65     37       3            3
EventProbe.bpf.o  fentry__taskstats_exit               success          21240  26453    1397           78
EventProbe.bpf.o  fentry__tcp_close                    success            315    474      26           26
EventProbe.bpf.o  fentry__tty_write                    success            312    561      25           25
EventProbe.bpf.o  fentry__vfs_rename                   success          42741  79651    3119          405
EventProbe.bpf.o  fentry__vfs_unlink                   success             61     37       3            3
EventProbe.bpf.o  fexit__chmod_common                  success          20273  40498    1607          232
EventProbe.bpf.o  fexit__chown_common                  success          20399  40498    1607          232
EventProbe.bpf.o  fexit__do_filp_open                  success          21687  40563    1581          252
EventProbe.bpf.o  fexit__do_truncate                   success          19951  40521    1609          234
EventProbe.bpf.o  fexit__inet_csk_accept               success            257    419      25           25
EventProbe.bpf.o  fexit__tcp_v4_connect                success            271    422      25           25
EventProbe.bpf.o  fexit__tcp_v6_connect                success            295    422      25           25
EventProbe.bpf.o  fexit__vfs_rename                    success            641   1423      50           50
EventProbe.bpf.o  fexit__vfs_unlink                    success          23231  40534    1579          251
EventProbe.bpf.o  fexit__vfs_write                     success          20329  40499    1608          233
EventProbe.bpf.o  fexit__vfs_writev                    success          20203  40499    1608          233
EventProbe.bpf.o  kprobe__chmod_common                 success             42     43       1            1
EventProbe.bpf.o  kprobe__chown_common                 success             40     41       1            1
EventProbe.bpf.o  kprobe__commit_creds                 success            331    740      35           35
EventProbe.bpf.o  kprobe__do_renameat2                 success             63     68       4            4
EventProbe.bpf.o  kprobe__do_truncate                  success             56     53       2            2
EventProbe.bpf.o  kprobe__do_unlinkat                  success             51     50       2            2
EventProbe.bpf.o  kprobe__mnt_want_write               success             46     37       3            3
EventProbe.bpf.o  kprobe__taskstats_exit               success          21216  26453    1397           78
EventProbe.bpf.o  kprobe__tcp_close                    success            298    474      26           26
EventProbe.bpf.o  kprobe__tcp_v4_connect               success             50     50       2            2
EventProbe.bpf.o  kprobe__tcp_v6_connect               success             54     50       2            2
EventProbe.bpf.o  kprobe__tty_write                    success            296    561      25           25
EventProbe.bpf.o  kprobe__vfs_rename                   success          44090  79648    3120          406
EventProbe.bpf.o  kprobe__vfs_unlink                   success             49     39       4            4
EventProbe.bpf.o  kprobe__vfs_write                    success             38     43       1            1
EventProbe.bpf.o  kprobe__vfs_writev                   success             40     43       1            1
EventProbe.bpf.o  kretprobe__chmod_common              success          20176  40508    1608          233
EventProbe.bpf.o  kretprobe__chown_common              success          20342  40508    1608          233
EventProbe.bpf.o  kretprobe__do_filp_open              success          23539  40563    1581          252
EventProbe.bpf.o  kretprobe__do_truncate               success          20021  40508    1608          233
EventProbe.bpf.o  kretprobe__inet_csk_accept           success            254    419      25           25
EventProbe.bpf.o  kretprobe__tcp_v4_connect            success            263    432      26           26
EventProbe.bpf.o  kretprobe__tcp_v6_connect            success            269    432      26           26
EventProbe.bpf.o  kretprobe__vfs_rename                success            611   1412      49           49
EventProbe.bpf.o  kretprobe__vfs_unlink                success          22675  40523    1578          250
EventProbe.bpf.o  kretprobe__vfs_write                 success          20209  40507    1608          233
EventProbe.bpf.o  kretprobe__vfs_writev                success          20298  40507    1608          233
EventProbe.bpf.o  sched_process_exec                   success          42198  67486    2987          292
EventProbe.bpf.o  sched_process_fork                   success          19213  26868    1416           99
EventProbe.bpf.o  tracepoint_syscalls_sys_exit_setsid  success            151    262      14           14
----------------  -----------------------------------  -------  -------------  -----  ------  -----------
Done. Processed 1 files, 0 programs. Skipped 50 files, 0 programs.
```