### PR TITLE
Add COMM to process events fork/exec/exit

### DIFF
--- a/GPL/Events/EbpfEventProto.h
+++ b/GPL/Events/EbpfEventProto.h
@@ -204,6 +204,7 @@ struct ebpf_process_fork_event {
     struct ebpf_pid_info parent_pids;
     struct ebpf_pid_info child_pids;
     struct ebpf_cred_info creds;
+    char comm[TASK_COMM_LEN];
 
     // Variable length fields: pids_ss_cgroup_path
     struct ebpf_varlen_fields_start vl_fields;
@@ -214,6 +215,7 @@ struct ebpf_process_exec_event {
     struct ebpf_pid_info pids;
     struct ebpf_cred_info creds;
     struct ebpf_tty_dev ctty;
+    char comm[TASK_COMM_LEN];
 
     // Variable length fields: cwd, argv, env, filename, pids_ss_cgroup_path
     struct ebpf_varlen_fields_start vl_fields;
@@ -223,6 +225,7 @@ struct ebpf_process_exit_event {
     struct ebpf_event_header hdr;
     struct ebpf_pid_info pids;
     int32_t exit_code;
+    char comm[TASK_COMM_LEN];
 
     // Variable length fields: pids_ss_cgroup_path
     struct ebpf_varlen_fields_start vl_fields;

--- a/GPL/Events/Helpers.h
+++ b/GPL/Events/Helpers.h
@@ -257,7 +257,7 @@ static void ebpf_cred_info__fill(struct ebpf_cred_info *ci, const struct task_st
 
 static void ebpf_comm__fill(char *comm, size_t len, const struct task_struct *task)
 {
-	read_kernel_str_or_empty_str(comm, len, BPF_CORE_READ(task, comm));
+    read_kernel_str_or_empty_str(comm, len, BPF_CORE_READ(task, comm));
 }
 
 static bool is_kernel_thread(const struct task_struct *task)

--- a/GPL/Events/Helpers.h
+++ b/GPL/Events/Helpers.h
@@ -255,6 +255,11 @@ static void ebpf_cred_info__fill(struct ebpf_cred_info *ci, const struct task_st
     }
 }
 
+static void ebpf_comm__fill(char *comm, size_t len, const struct task_struct *task)
+{
+	read_kernel_str_or_empty_str(comm, len, BPF_CORE_READ(task, comm));
+}
+
 static bool is_kernel_thread(const struct task_struct *task)
 {
     // All kernel threads are children of kthreadd, which always has pid 2

--- a/GPL/Events/Process/Probe.bpf.c
+++ b/GPL/Events/Process/Probe.bpf.c
@@ -53,6 +53,7 @@ int BPF_PROG(sched_process_fork, const struct task_struct *parent, const struct 
     ebpf_pid_info__fill(&event->parent_pids, parent);
     ebpf_pid_info__fill(&event->child_pids, child);
     ebpf_cred_info__fill(&event->creds, parent);
+    ebpf_comm__fill(event->comm, sizeof(event->comm), child);
 
     // Variable length fields
     ebpf_vl_fields__init(&event->vl_fields);
@@ -94,6 +95,7 @@ int BPF_PROG(sched_process_exec,
     ebpf_pid_info__fill(&event->pids, task);
     ebpf_cred_info__fill(&event->creds, task);
     ebpf_ctty__fill(&event->ctty, task);
+    ebpf_comm__fill(event->comm, sizeof(event->comm), task);
 
     // Variable length fields
     ebpf_vl_fields__init(&event->vl_fields);
@@ -165,6 +167,7 @@ static int taskstats_exit__enter(const struct task_struct *task, int group_dead)
     int exit_code    = BPF_CORE_READ(task, exit_code);
     event->exit_code = (exit_code >> 8) & 0xFF;
     ebpf_pid_info__fill(&event->pids, task);
+    ebpf_comm__fill(event->comm, sizeof(event->comm), task);
 
     // Variable length fields
     ebpf_vl_fields__init(&event->vl_fields);

--- a/non-GPL/Events/EventsTrace/EventsTrace.c
+++ b/non-GPL/Events/EventsTrace/EventsTrace.c
@@ -605,6 +605,9 @@ static void out_process_fork(struct ebpf_process_fork_event *evt)
     out_comma();
 
     out_cred_info("creds", &evt->creds);
+    out_comma();
+
+    out_string("comm", evt->comm);
 
     struct ebpf_varlen_field *field;
     FOR_EACH_VARLEN_FIELD(evt->vl_fields, field)
@@ -637,6 +640,9 @@ static void out_process_exec(struct ebpf_process_exec_event *evt)
     out_comma();
 
     out_tty_dev("ctty", &evt->ctty);
+    out_comma();
+
+    out_string("comm", evt->comm);
 
     struct ebpf_varlen_field *field;
     FOR_EACH_VARLEN_FIELD(evt->vl_fields, field)
@@ -751,6 +757,9 @@ static void out_process_exit(struct ebpf_process_exit_event *evt)
     out_comma();
 
     out_pid_info("pids", &evt->pids);
+    out_comma();
+
+    out_string("comm", evt->comm);
     out_comma();
 
     out_int("exit_code", evt->exit_code);


### PR DESCRIPTION
This is needed by quark and it makes sense at any rate since we don't track COMM changes explicitly (setproctitle and friends).