### PR TITLE
Add creds to the exit probe

### DIFF
--- a/GPL/Events/EbpfEventProto.h
+++ b/GPL/Events/EbpfEventProto.h
@@ -224,6 +224,7 @@ struct ebpf_process_exec_event {
 struct ebpf_process_exit_event {
     struct ebpf_event_header hdr;
     struct ebpf_pid_info pids;
+    struct ebpf_cred_info creds;
     int32_t exit_code;
     char comm[TASK_COMM_LEN];
 

--- a/GPL/Events/Process/Probe.bpf.c
+++ b/GPL/Events/Process/Probe.bpf.c
@@ -167,6 +167,7 @@ static int taskstats_exit__enter(const struct task_struct *task, int group_dead)
     int exit_code    = BPF_CORE_READ(task, exit_code);
     event->exit_code = (exit_code >> 8) & 0xFF;
     ebpf_pid_info__fill(&event->pids, task);
+    ebpf_cred_info__fill(&event->creds, task);
     ebpf_comm__fill(event->comm, sizeof(event->comm), task);
 
     // Variable length fields


### PR DESCRIPTION
Keeps consistency with fork and exec, also needed by quark.