### PR TITLE
Condense is_foo from exec into flags.

### DIFF
--- a/GPL/Events/EbpfEventProto.h
+++ b/GPL/Events/EbpfEventProto.h
@@ -226,6 +226,10 @@ struct ebpf_process_fork_event {
     struct ebpf_varlen_fields_start vl_fields;
 } __attribute__((packed));
 
+#define EXEC_F_SETUID	(1 << 0)
+#define EXEC_F_SETGID	(1 << 1)
+#define EXEC_F_MEMFD	(1 << 2)
+
 struct ebpf_process_exec_event {
     struct ebpf_event_header hdr;
     struct ebpf_pid_info pids;
@@ -233,9 +237,7 @@ struct ebpf_process_exec_event {
     struct ebpf_tty_dev ctty;
     char comm[TASK_COMM_LEN];
     unsigned int inode_nlink;
-    bool is_setuid;
-    bool is_setgid;
-    bool is_memfd;
+    uint32_t flags;
 
     // Variable length fields: cwd, argv, env, filename, pids_ss_cgroup_path
     struct ebpf_varlen_fields_start vl_fields;

--- a/non-GPL/Events/EventsTrace/EventsTrace.c
+++ b/non-GPL/Events/EventsTrace/EventsTrace.c
@@ -790,11 +790,11 @@ static void out_process_exec(struct ebpf_process_exec_event *evt)
     out_string("comm", evt->comm);
     out_comma();
 
-    out_bool("is_setuid", evt->is_setuid);
+    out_bool("is_setuid", evt->flags & EXEC_F_SETUID);
     out_comma();
-    out_bool("is_setgid", evt->is_setgid);
+    out_bool("is_setgid", evt->flags & EXEC_F_SETGID);
     out_comma();
-    out_bool("is_memfd", evt->is_memfd);
+    out_bool("is_memfd", evt->flags & EXEC_F_MEMFD);
     out_comma();
     unsigned int nlinks = evt->inode_nlink;
     out_uint("inode_nlinks", nlinks);


### PR DESCRIPTION
Compiles and runs, needs proper testing and cleanup.
