### PR TITLE
Add ctty to fork

### DIFF
--- a/GPL/Events/EbpfEventProto.h
+++ b/GPL/Events/EbpfEventProto.h
@@ -213,6 +213,7 @@ struct ebpf_process_fork_event {
     struct ebpf_pid_info parent_pids;
     struct ebpf_pid_info child_pids;
     struct ebpf_cred_info creds;
+    struct ebpf_tty_dev ctty;
     char comm[TASK_COMM_LEN];
 
     // Variable length fields: pids_ss_cgroup_path

--- a/GPL/Events/Process/Probe.bpf.c
+++ b/GPL/Events/Process/Probe.bpf.c
@@ -16,6 +16,7 @@
 #include "Helpers.h"
 #include "PathResolver.h"
 #include "Varlen.h"
+#include "State.h"
 
 /* tty_write */
 DECL_FIELD_OFFSET(iov_iter, __iov);
@@ -56,6 +57,7 @@ int BPF_PROG(sched_process_fork, const struct task_struct *parent, const struct 
     ebpf_pid_info__fill(&event->parent_pids, parent);
     ebpf_pid_info__fill(&event->child_pids, child);
     ebpf_cred_info__fill(&event->creds, parent);
+    ebpf_ctty__fill(&event->ctty, child);
     ebpf_comm__fill(event->comm, sizeof(event->comm), child);
 
     // Variable length fields

--- a/non-GPL/Events/EventsTrace/EventsTrace.c
+++ b/non-GPL/Events/EventsTrace/EventsTrace.c
@@ -752,6 +752,9 @@ static void out_process_fork(struct ebpf_process_fork_event *evt)
     out_cred_info("creds", &evt->creds);
     out_comma();
 
+    out_tty_dev("ctty", &evt->ctty);
+    out_comma();
+
     out_string("comm", evt->comm);
 
     struct ebpf_varlen_field *field;


### PR DESCRIPTION
Since we don't track actual TTY changes, at least make sure a new process gets the correct TTY, previously we were tracking it only on exec which is fine for probably most cases.