### PR TITLE
Add cwd to fork and ctty to exit.

### DIFF
--- a/GPL/Events/EbpfEventProto.h
+++ b/GPL/Events/EbpfEventProto.h
@@ -241,8 +241,9 @@ struct ebpf_process_exit_event {
     struct ebpf_event_header hdr;
     struct ebpf_pid_info pids;
     struct ebpf_cred_info creds;
-    int32_t exit_code;
+    struct ebpf_tty_dev ctty;
     char comm[TASK_COMM_LEN];
+    int32_t exit_code;
 
     // Variable length fields: pids_ss_cgroup_path
     struct ebpf_varlen_fields_start vl_fields;

--- a/GPL/Events/Process/Probe.bpf.c
+++ b/GPL/Events/Process/Probe.bpf.c
@@ -70,6 +70,11 @@ int BPF_PROG(sched_process_fork, const struct task_struct *parent, const struct 
     size  = ebpf_resolve_pids_ss_cgroup_path_to_string(field->data, child);
     ebpf_vl_field__set_size(&event->vl_fields, field, size);
 
+    // cwd
+    field = ebpf_vl_field__add(&event->vl_fields, EBPF_VL_FIELD_CWD);
+    size  = ebpf_resolve_path_to_string(field->data, &child->fs->pwd, child);
+    ebpf_vl_field__set_size(&event->vl_fields, field, size);
+
     bpf_ringbuf_output(&ringbuf, event, EVENT_SIZE(event), 0);
 
 out:
@@ -201,6 +206,7 @@ static int taskstats_exit__enter(const struct task_struct *task, int group_dead)
     event->exit_code = (exit_code >> 8) & 0xFF;
     ebpf_pid_info__fill(&event->pids, task);
     ebpf_cred_info__fill(&event->creds, task);
+    ebpf_ctty__fill(&event->ctty, task);
     ebpf_comm__fill(event->comm, sizeof(event->comm), task);
 
     // Variable length fields

--- a/non-GPL/Events/EventsTrace/EventsTrace.c
+++ b/non-GPL/Events/EventsTrace/EventsTrace.c
@@ -765,6 +765,9 @@ static void out_process_fork(struct ebpf_process_fork_event *evt)
         case EBPF_VL_FIELD_PIDS_SS_CGROUP_PATH:
             out_string("pids_ss_cgroup_path", field->data);
             break;
+        case EBPF_VL_FIELD_CWD:
+            out_string("cwd", field->data);
+            break;
         default:
             fprintf(stderr, "Unexpected variable length field: %d\n", field->type);
             break;
@@ -915,6 +918,9 @@ static void out_process_exit(struct ebpf_process_exit_event *evt)
     out_comma();
 
     out_pid_info("pids", &evt->pids);
+    out_comma();
+
+    out_tty_dev("ctty", &evt->ctty);
     out_comma();
 
     out_string("comm", evt->comm);


### PR DESCRIPTION
This unifies what fork+exec+exit outputs once and for all. cwd cannot be gathered on exit as it's already gone by the time we try to fetch it.