### PR TITLE
Use `FUNC_RET_READ` for `inet_csk_accept`

### DIFF
--- a/GPL/Events/Helpers.h
+++ b/GPL/Events/Helpers.h
@@ -113,6 +113,7 @@ const volatile int consumer_pid = 0;
         ret;                                                                                       \
     })
 
+// value is replaced later by `probe_fill_relos()`
 #define DECL_FUNC_RET(func) const volatile int ret__##func##__ = 0;
 #define FUNC_RET_READ(type, func)                                                                  \
     ({                                                                                             \

--- a/GPL/Events/Network/Probe.bpf.c
+++ b/GPL/Events/Network/Probe.bpf.c
@@ -18,6 +18,8 @@
 #include "Network.h"
 #include "State.h"
 
+DECL_FUNC_RET(inet_csk_accept);
+
 static int inet_csk_accept__exit(struct sock *sk)
 {
     if (!sk)
@@ -42,9 +44,9 @@ out:
 }
 
 SEC("fexit/inet_csk_accept")
-int BPF_PROG(
-    fexit__inet_csk_accept, struct sock *sk, int flags, int *err, bool kern, struct sock *ret)
+int BPF_PROG(fexit__inet_csk_accept)
 {
+    struct sock *ret = FUNC_RET_READ(___type(ret), inet_csk_accept);
     return inet_csk_accept__exit(ret);
 }
 

--- a/non-GPL/Events/Lib/EbpfEvents.c
+++ b/non-GPL/Events/Lib/EbpfEvents.c
@@ -268,7 +268,7 @@ static int probe_fill_relos(struct btf *btf, struct EventProbe_bpf *obj)
 {
     int err = 0;
 
-    err = err ?: FILL_FUNC_RET_IDX(obj,btf, inet_csk_accept);
+    err = err ?: FILL_FUNC_RET_IDX(obj, btf, inet_csk_accept);
 
     err = err ?: FILL_FUNC_ARG_IDX(obj, btf, vfs_unlink, dentry);
     err = err ?: FILL_FUNC_RET_IDX(obj, btf, vfs_unlink);

--- a/non-GPL/Events/Lib/EbpfEvents.c
+++ b/non-GPL/Events/Lib/EbpfEvents.c
@@ -268,6 +268,8 @@ static int probe_fill_relos(struct btf *btf, struct EventProbe_bpf *obj)
 {
     int err = 0;
 
+    err = err ?: FILL_FUNC_RET_IDX(obj,btf, inet_csk_accept);
+
     err = err ?: FILL_FUNC_ARG_IDX(obj, btf, vfs_unlink, dentry);
     err = err ?: FILL_FUNC_RET_IDX(obj, btf, vfs_unlink);
 


### PR DESCRIPTION
closes https://github.com/elastic/ebpf/issues/200

This changes the `inet_csk_accept` fexit probe to use `FUNC_RET_READ` instead of passing args to the method; this means we don't have to deal with the function arguments changing, like with the 6.10 kernel.


Tested on Fedora with 6.10.3, but we seem to be missing the addr fields. Not sure if this is a quirk of using the fexit probe, or if there's a bug here and the `inet_csk_accept` method no longer works the way we assume.
```
sudo ./EventsTrace --net-conn-accept -i                                                                                                                                                   
{"probes_initialized": true, "features": {"bpf_tramp": true}}
{"event_type":"NETWORK_CONNECTION_ACCEPTED","pids":{"tid":4184470,"tgid":4184470,"ppid":4145903,"pgid":4184470,"sid":4145903,"start_time_ns":1468277566951535},"net":{"transport":"TCP","family":"AF_INET","source_address":"0.0.0.0","source_port":8000,"destination_address":"0.0.0.0","destination_port":0,"network_namespace":4026531840},"comm":"python3"}
```