### PR TITLE
Include namespace inode numbers on process events

### DIFF
--- a/GPL/Events/EbpfEventProto.h
+++ b/GPL/Events/EbpfEventProto.h
@@ -157,6 +157,16 @@ struct ebpf_file_info {
     uint64_t ctime;
 } __attribute__((packed));
 
+struct ebpf_namespace_info {
+    uint32_t uts_inonum;
+    uint32_t ipc_inonum;
+    uint32_t mnt_inonum;
+    uint32_t net_inonum;
+    uint32_t cgroup_inonum;
+    uint32_t time_inonum;
+    uint32_t pid_inonum;
+} __attribute__((packed));
+
 // Full events follow
 struct ebpf_file_delete_event {
     struct ebpf_event_header hdr;
@@ -223,6 +233,7 @@ struct ebpf_process_fork_event {
     struct ebpf_cred_info creds;
     struct ebpf_tty_dev ctty;
     char comm[TASK_COMM_LEN];
+    struct ebpf_namespace_info ns;
 
     // Variable length fields: pids_ss_cgroup_path
     struct ebpf_varlen_fields_start vl_fields;
@@ -238,6 +249,7 @@ struct ebpf_process_exec_event {
     struct ebpf_cred_info creds;
     struct ebpf_tty_dev ctty;
     char comm[TASK_COMM_LEN];
+    struct ebpf_namespace_info ns;
     uint32_t inode_nlink;
     uint32_t flags;
 
@@ -251,6 +263,7 @@ struct ebpf_process_exit_event {
     struct ebpf_cred_info creds;
     struct ebpf_tty_dev ctty;
     char comm[TASK_COMM_LEN];
+    struct ebpf_namespace_info ns;
     int32_t exit_code;
 
     // Variable length fields: pids_ss_cgroup_path

--- a/GPL/Events/Process/Probe.bpf.c
+++ b/GPL/Events/Process/Probe.bpf.c
@@ -60,6 +60,7 @@ int BPF_PROG(sched_process_fork, const struct task_struct *parent, const struct 
     ebpf_cred_info__fill(&event->creds, parent);
     ebpf_ctty__fill(&event->ctty, child);
     ebpf_comm__fill(event->comm, sizeof(event->comm), child);
+    ebpf_ns__fill(&event->ns, child);
 
     // Variable length fields
     ebpf_vl_fields__init(&event->vl_fields);
@@ -111,6 +112,7 @@ int BPF_PROG(sched_process_exec,
     ebpf_cred_info__fill(&event->creds, task);
     ebpf_ctty__fill(&event->ctty, task);
     ebpf_comm__fill(event->comm, sizeof(event->comm), task);
+    ebpf_ns__fill(&event->ns, task);
 
     // set setuid and setgid flags
     struct file *f        = BPF_CORE_READ(binprm, file);
@@ -211,6 +213,7 @@ static int taskstats_exit__enter(const struct task_struct *task, int group_dead)
     ebpf_cred_info__fill(&event->creds, task);
     ebpf_ctty__fill(&event->ctty, task);
     ebpf_comm__fill(event->comm, sizeof(event->comm), task);
+    ebpf_ns__fill(&event->ns, task);
 
     // Variable length fields
     ebpf_vl_fields__init(&event->vl_fields);

--- a/non-GPL/Events/EventsTrace/EventsTrace.c
+++ b/non-GPL/Events/EventsTrace/EventsTrace.c
@@ -414,6 +414,26 @@ static void out_file_info(const char *name, struct ebpf_file_info *finfo)
     out_object_end();
 }
 
+static void out_ns_info(const char *name, struct ebpf_namespace_info *ns)
+{
+    printf("\"%s\":", name);
+    out_object_start();
+    out_uint("uts", ns->uts_inonum);
+    out_comma();
+    out_uint("ipc", ns->ipc_inonum);
+    out_comma();
+    out_uint("mnt", ns->mnt_inonum);
+    out_comma();
+    out_uint("net", ns->net_inonum);
+    out_comma();
+    out_uint("cgroup", ns->cgroup_inonum);
+    out_comma();
+    out_uint("time", ns->time_inonum);
+    out_comma();
+    out_uint("pid", ns->pid_inonum);
+    out_object_end();
+}
+
 static void out_null_delimited_string_array(const char *name, char *buf, size_t buf_size)
 {
     // buf is an array (argv, env etc.) with multiple values delimited by a '\0'
@@ -768,6 +788,9 @@ static void out_process_fork(struct ebpf_process_fork_event *evt)
     out_comma();
 
     out_string("comm", evt->comm);
+    out_comma();
+
+    out_ns_info("ns", &evt->ns);
 
     struct ebpf_varlen_field *field;
     FOR_EACH_VARLEN_FIELD(evt->vl_fields, field)

--- a/testing/scripts/gen_initramfs.sh
+++ b/testing/scripts/gen_initramfs.sh
@@ -56,7 +56,7 @@ build_testbins() {
     for c_src in *.c; do
         local bin_path=bin/$arch/$(basename $c_src .c)
 
-        ${arch}-linux-gnu-gcc -g -static $c_src -o $bin_path \
+        ${CC-${arch}-linux-gnu-gcc} -g -static $c_src -o $bin_path \
             || exit_error "compilation of $c_src for $arch failed (see above)"
     done
 

--- a/testing/testrunner/ebpf_test.go
+++ b/testing/testrunner/ebpf_test.go
@@ -94,6 +94,11 @@ func ForkExit(t *testing.T, et *Runner) {
 	require.Equal(t, forkEvent.ChildPids.Sid, forkEvent.ParentPids.Sid)
 	require.Equal(t, forkEvent.ChildPids.Pgid, forkEvent.ParentPids.Pgid)
 	require.NotEqual(t, forkEvent.ChildPids.Tgid, forkEvent.ParentPids.Tgid)
+
+	// Check if all namespace values match /proc/self/ns/*
+	ns, err := FetchNsFromProc()
+	require.NoError(t, err)
+	require.Equal(t, forkEvent.Ns, ns)
 }
 
 func ForkExec(t *testing.T, et *Runner) {
@@ -154,7 +159,6 @@ func ForkExec(t *testing.T, et *Runner) {
 	require.Equal(t, execEvent.Env[0], "TEST_ENV_KEY1=TEST_ENV_VAL1")
 	require.Equal(t, execEvent.Env[1], "TEST_ENV_KEY2=TEST_ENV_VAL2")
 	require.Equal(t, execEvent.Cwd, "/")
-
 }
 
 func FileCreate(t *testing.T, et *Runner) {
@@ -185,7 +189,6 @@ func FileCreate(t *testing.T, et *Runner) {
 }
 
 func FileDelete(t *testing.T, et *Runner) {
-
 	var binOutput struct {
 		PidInfo      TestPidInfo `json:"pid_info"`
 		FileNameOrig string      `json:"filename_orig"`
@@ -426,7 +429,6 @@ func Tcpv4ConnectionAttempt(t *testing.T, et *Runner) {
 	require.Equal(t, ev.Net.DestPort, binOutput.ServerPort)
 	require.Equal(t, ev.Net.NetNs, binOutput.NetNs)
 	require.Equal(t, ev.Comm, "tcpv4_connect")
-
 }
 
 func Tcpv4ConnectionAccept(t *testing.T, et *Runner) {
@@ -665,5 +667,4 @@ func TestEbpf(t *testing.T) {
 			run.Stop()
 		})
 	}
-
 }


### PR DESCRIPTION
This diff adds the inode number of each namespace the process belongs to, to process events. Two namespaces were excluded: pid_for_children and time_for_children, see namespaces(7).

The pid namespace is a bit special as it's not in nsproxy, the user facing pid level is the last/deepest.

There was an inclusion of mnt ns, that is not used by beats or endpoint, I kept it but made it fetch from the new "path".

While here, add support for changing the compiler in gen_initramfs.sh by setting CC. While Fedora includes a ${arch}-linux-gnu-gcc, it doesn't include matching headers, so I can't really compile the tests locally.