### PR TITLE
Hook exit only after descriptors are closed. Fixes #216

### DIFF
--- a/GPL/Events/Process/Probe.bpf.c
+++ b/GPL/Events/Process/Probe.bpf.c
@@ -205,7 +205,8 @@ static int taskstats_exit__enter(const struct task_struct *task, int group_dead)
     return 0;
 }
 
-static int do_exit(const struct task_struct *task)
+SEC("tp_btf/sched_process_exit")
+int BPF_PROG(sched_process_exit, const struct task_struct *task)
 {
     struct ebpf_process_exit_event *event;
 
@@ -254,18 +255,6 @@ SEC("kprobe/taskstats_exit")
 int BPF_KPROBE(kprobe__taskstats_exit, const struct task_struct *task, int group_dead)
 {
     return taskstats_exit__enter(task, group_dead);
-}
-
-SEC("kprobe/proc_exit_connector")
-int BPF_KPROBE(kprobe__proc_exit_connector, const struct task_struct *task)
-{
-    return do_exit(task);
-}
-
-SEC("fentry/proc_exit_connector")
-int BPF_PROG(fentry__proc_exit_connector, const struct task_struct *task)
-{
-    return do_exit(task);
 }
 
 // tracepoint/syscalls/sys_[enter/exit]_[name] tracepoints are not available

--- a/GPL/Events/State.h
+++ b/GPL/Events/State.h
@@ -21,6 +21,7 @@ enum ebpf_events_state_op {
     EBPF_EVENTS_STATE_WRITE          = 7,
     EBPF_EVENTS_STATE_WRITEV         = 8,
     EBPF_EVENTS_STATE_CHOWN          = 9,
+    EBPF_EVENTS_STATE_GROUP_DEAD     = 10,
 };
 
 struct ebpf_events_key {
@@ -91,6 +92,7 @@ struct ebpf_events_state {
         struct ebpf_events_write_state write;
         struct ebpf_events_writev_state writev;
         struct ebpf_events_chown_state chown;
+        /* struct ebpf_events_group_dead group_dead; nada */
     };
 };
 

--- a/non-GPL/Events/Lib/EbpfEvents.c
+++ b/non-GPL/Events/Lib/EbpfEvents.c
@@ -373,7 +373,6 @@ static inline int probe_set_autoload(struct btf *btf, struct EventProbe_bpf *obj
         err = err ?: bpf_program__set_autoload(obj->progs.kprobe__vfs_rename, false);
         err = err ?: bpf_program__set_autoload(obj->progs.kretprobe__vfs_rename, false);
         err = err ?: bpf_program__set_autoload(obj->progs.kprobe__taskstats_exit, false);
-        err = err ?: bpf_program__set_autoload(obj->progs.kprobe__proc_exit_connector, false);
         err = err ?: bpf_program__set_autoload(obj->progs.kprobe__commit_creds, false);
         err = err ?: bpf_program__set_autoload(obj->progs.kretprobe__inet_csk_accept, false);
         err = err ?: bpf_program__set_autoload(obj->progs.kprobe__tcp_v4_connect, false);
@@ -398,7 +397,6 @@ static inline int probe_set_autoload(struct btf *btf, struct EventProbe_bpf *obj
         err = err ?: bpf_program__set_autoload(obj->progs.fentry__vfs_rename, false);
         err = err ?: bpf_program__set_autoload(obj->progs.fexit__vfs_rename, false);
         err = err ?: bpf_program__set_autoload(obj->progs.fentry__taskstats_exit, false);
-        err = err ?: bpf_program__set_autoload(obj->progs.fentry__proc_exit_connector, false);
         err = err ?: bpf_program__set_autoload(obj->progs.fentry__commit_creds, false);
         err = err ?: bpf_program__set_autoload(obj->progs.fexit__inet_csk_accept, false);
         err = err ?: bpf_program__set_autoload(obj->progs.fexit__tcp_v4_connect, false);

--- a/non-GPL/Events/Lib/EbpfEvents.c
+++ b/non-GPL/Events/Lib/EbpfEvents.c
@@ -373,6 +373,7 @@ static inline int probe_set_autoload(struct btf *btf, struct EventProbe_bpf *obj
         err = err ?: bpf_program__set_autoload(obj->progs.kprobe__vfs_rename, false);
         err = err ?: bpf_program__set_autoload(obj->progs.kretprobe__vfs_rename, false);
         err = err ?: bpf_program__set_autoload(obj->progs.kprobe__taskstats_exit, false);
+        err = err ?: bpf_program__set_autoload(obj->progs.kprobe__proc_exit_connector, false);
         err = err ?: bpf_program__set_autoload(obj->progs.kprobe__commit_creds, false);
         err = err ?: bpf_program__set_autoload(obj->progs.kretprobe__inet_csk_accept, false);
         err = err ?: bpf_program__set_autoload(obj->progs.kprobe__tcp_v4_connect, false);
@@ -397,6 +398,7 @@ static inline int probe_set_autoload(struct btf *btf, struct EventProbe_bpf *obj
         err = err ?: bpf_program__set_autoload(obj->progs.fentry__vfs_rename, false);
         err = err ?: bpf_program__set_autoload(obj->progs.fexit__vfs_rename, false);
         err = err ?: bpf_program__set_autoload(obj->progs.fentry__taskstats_exit, false);
+        err = err ?: bpf_program__set_autoload(obj->progs.fentry__proc_exit_connector, false);
         err = err ?: bpf_program__set_autoload(obj->progs.fentry__commit_creds, false);
         err = err ?: bpf_program__set_autoload(obj->progs.fexit__inet_csk_accept, false);
         err = err ?: bpf_program__set_autoload(obj->progs.fexit__tcp_v4_connect, false);


### PR DESCRIPTION
Previously we were sending exit events before the file descriptors were closed. The tests are likely naive enough to always properly close the socket and then terminate. This is easy to see by connecting and killing it.

The solution is to move the hook down to ~~proc_exit_connector()~~ sched_process_exit(). In order to respect the group_dead dance we have to now keep state of who got it, we use an empty state, meaning the existence of the entry in the map is the state.