### PR TITLE
Single non-annotated entrypoints fix

### DIFF
--- a/GPL/HostIsolation/TcFilter/BPFTcFilterTests.cpp
+++ b/GPL/HostIsolation/TcFilter/BPFTcFilterTests.cpp
@@ -21,7 +21,7 @@
 
 #define OBJECT_PATH_ENV_VAR "ELASTIC_EBPF_TC_FILTER_OBJ_PATH"
 #define DEFAULT_OBJECT_PATH "TcFilter.bpf.o"
-#define CLASSIFIER_SECTION_NAME "classifier"
+#define CLASSIFIER_PROGRAM_NAME "tc_filter"
 
 #define MAGIC_BYTES 123
 #define __packed __attribute__((__packed__))
@@ -63,7 +63,7 @@ class BPFTcFilterTests : public ::testing::Test
                    << OBJECT_PATH_ENV_VAR << " environment variable";
         }
 
-        prog = bpf_object__find_program_by_name(m_obj, CLASSIFIER_SECTION_NAME);
+        prog = bpf_object__find_program_by_name(m_obj, CLASSIFIER_PROGRAM_NAME);
         ASSERT_FALSE(prog == NULL);
 
         bpf_program__set_type(prog, BPF_PROG_TYPE_SCHED_CLS);

--- a/GPL/HostIsolation/TcFilter/TcFilter.bpf.c
+++ b/GPL/HostIsolation/TcFilter/TcFilter.bpf.c
@@ -101,7 +101,7 @@ __attribute__((always_inline)) static int allow_udp_pkt_egress(struct udphdr *ud
     }
 }
 
-int classifier(struct __sk_buff *skb)
+__section("classifer") int tc_filter(struct __sk_buff *skb)
 {
     struct ethhdr *eth = NULL;
     struct iphdr *ip   = NULL;


### PR DESCRIPTION
Newer versions of libbpf (starting https://github.com/libbpf/libbpf/commit/ac9ced9eb3d344407ba78976f3e88276453c8eaf) refuse to load programs with a single non-annotated entry point. The commit forces the entry point of the TcFilter program into the "classifier" section, renames the function to tc_filter, and updates the unit tests.