### PR TITLE
Do not load DNS probes 

### DIFF
--- a/non-GPL/Events/Lib/EbpfEvents.c
+++ b/non-GPL/Events/Lib/EbpfEvents.c
@@ -417,6 +417,7 @@ static int probe_set_autoload(struct btf *btf, struct EventProbe_bpf *obj, uint6
     return err;
 }
 
+#if 0 // Do not load DNS probes
 static int probe_attach_cgroup(struct EventProbe_bpf *obj)
 {
     int cgroup_fd;
@@ -446,6 +447,7 @@ static int probe_attach_cgroup(struct EventProbe_bpf *obj)
 
     return 0;
 }
+#endif
 
 static bool system_has_bpf_tramp(void)
 {
@@ -790,11 +792,13 @@ int ebpf_event_ctx__new(struct ebpf_event_ctx **ctx, ebpf_event_handler_fn cb, u
         goto out_destroy_probe;
     }
 
+#if 0 // Do not load DNS probes
     err = probe_attach_cgroup(probe);
     if (err != 0) {
         verbose("probe_attach_cgroup: %d\n", err);
         goto out_destroy_probe;
     }
+#endif
 
     if (!ctx)
         goto out_destroy_probe;

--- a/testing/testrunner/ebpf_test.go
+++ b/testing/testrunner/ebpf_test.go
@@ -773,7 +773,7 @@ func TestEbpf(t *testing.T) {
 		{"Tcpv4ConnectionAttempt", Tcpv4ConnectionAttempt, []string{"--net-conn-attempt"}, false},
 		{"Tcpv4ConnectionAccept", Tcpv4ConnectionAccept, []string{"--net-conn-accept"}, false},
 		{"Tcpv4ConnectionClose", Tcpv4ConnectionClose, []string{"--net-conn-close"}, false},
-		{"DNSMonitor", DNSMonitor, []string{"--net-conn-dns-pkt"}, false},
+		//{"DNSMonitor", DNSMonitor, []string{"--net-conn-dns-pkt"}, false},
 		{"Ptrace", Ptrace, []string{"--process-ptrace"}, false},
 		{"Shmget", Shmget, []string{"--process-shmget"}, false},
 		{"MemfdCreate", MemfdCreate, []string{"--process-memfd-create", "--process-exec"}, false},


### PR DESCRIPTION
Elastic products do not ingest DNS events when using this repo's loader. DNS events require cgroup2 be mounted on the host. This is causing failures in amazon2 machines where ebpf probes would otherwise be supported but cgroup2 is not mounted.

This PR disables the cgroup based probes from being loaded and tested.
