### PR TITLE
Avoid taskstats_exit and sched_process_exit

### DIFF
--- a/GPL/Events/State.h
+++ b/GPL/Events/State.h
@@ -21,7 +21,6 @@ enum ebpf_events_state_op {
     EBPF_EVENTS_STATE_WRITE          = 7,
     EBPF_EVENTS_STATE_WRITEV         = 8,
     EBPF_EVENTS_STATE_CHOWN          = 9,
-    EBPF_EVENTS_STATE_GROUP_DEAD     = 10,
 };
 
 struct ebpf_events_key {
@@ -92,7 +91,6 @@ struct ebpf_events_state {
         struct ebpf_events_write_state write;
         struct ebpf_events_writev_state writev;
         struct ebpf_events_chown_state chown;
-        /* struct ebpf_events_group_dead group_dead; nada */
     };
 };
 

--- a/non-GPL/Events/Lib/EbpfEvents.c
+++ b/non-GPL/Events/Lib/EbpfEvents.c
@@ -381,7 +381,7 @@ static int probe_set_autoload(struct btf *btf, struct EventProbe_bpf *obj, uint6
         err = err ?: bpf_program__set_autoload(obj->progs.kretprobe__do_filp_open, false);
         err = err ?: bpf_program__set_autoload(obj->progs.kprobe__vfs_rename, false);
         err = err ?: bpf_program__set_autoload(obj->progs.kretprobe__vfs_rename, false);
-        err = err ?: bpf_program__set_autoload(obj->progs.kprobe__taskstats_exit, false);
+        err = err ?: bpf_program__set_autoload(obj->progs.kprobe__disassociate_ctty, false);
         err = err ?: bpf_program__set_autoload(obj->progs.kprobe__commit_creds, false);
         err = err ?: bpf_program__set_autoload(obj->progs.kretprobe__inet_csk_accept, false);
         err = err ?: bpf_program__set_autoload(obj->progs.kprobe__tcp_v4_connect, false);
@@ -403,7 +403,7 @@ static int probe_set_autoload(struct btf *btf, struct EventProbe_bpf *obj, uint6
         err = err ?: bpf_program__set_autoload(obj->progs.fexit__do_filp_open, false);
         err = err ?: bpf_program__set_autoload(obj->progs.fentry__vfs_rename, false);
         err = err ?: bpf_program__set_autoload(obj->progs.fexit__vfs_rename, false);
-        err = err ?: bpf_program__set_autoload(obj->progs.fentry__taskstats_exit, false);
+        err = err ?: bpf_program__set_autoload(obj->progs.fentry__disassociate_ctty, false);
         err = err ?: bpf_program__set_autoload(obj->progs.fentry__commit_creds, false);
         err = err ?: bpf_program__set_autoload(obj->progs.fexit__inet_csk_accept, false);
         err = err ?: bpf_program__set_autoload(obj->progs.fexit__tcp_v4_connect, false);
@@ -473,7 +473,7 @@ static bool system_has_bpf_tramp(void)
         {.code = BPF_EXIT | BPF_JMP, .dst_reg = 0, .src_reg = 0, .off = 0, .imm = 0}};
     int insns_cnt = 2;
 
-    btf_id = btf__find_by_name(btf, "taskstats_exit");
+    btf_id = btf__find_by_name(btf, "disassociate_ctty");
     LIBBPF_OPTS(bpf_prog_load_opts, opts, .log_buf = NULL, .log_level = 0,
                 .expected_attach_type = BPF_TRACE_FENTRY, .attach_btf_id = btf_id);
     prog_fd = bpf_prog_load(BPF_PROG_TYPE_TRACING, NULL, "GPL", insns, insns_cnt, &opts);


### PR DESCRIPTION
taskstats_exit can be compiled out based on kernel configuration. Instead use disassociate_ctty(1) as an indication that group_dead has been set. sched_process_exit is called before exit_files, so it's possible that a socket disconnect event could be emitted after a process termination. instead use exit_task_namespaces to emit the exit event. we had little choice in the matter since sched_process_exit is executed before disassociate_ctty, but sched_process_exit was still the incorrect spot to emit an exit event and worth noting.